### PR TITLE
C extension is not built

### DIFF
--- a/sphere/setup_package.py
+++ b/sphere/setup_package.py
@@ -3,5 +3,17 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+from distutils.core import Extension
+import os
+
+
 def requires_2to3():
     return False
+
+
+def get_extensions():
+    ROOT = os.path.relpath(os.path.dirname(__file__))
+
+    return [Extension(
+        str('sphere.math_util'),
+        [str(os.path.join(ROOT, 'src/math_util.c'))])]


### PR DESCRIPTION
Surprised I just noticed this -- the C extension, math_util.c, is never built and used -- instead, we're falling back on the Python implementations here.

Self-assigning.
