### PR TITLE
Make numpy.linspace step count an integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,6 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
 
-    # Remove this when DeprecationWarning is fixed
-    allow_failures:
-        - python: 3.6
-          env: NUMPY_VERSION=1.12 SETUP_CMD='test'
-
 before_install:
 
     # Use utf8 encoding. Should be default, but this is insurance against

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -199,7 +199,7 @@ class _SingleSphericalPolygon(object):
                    auto_orient=auto_orient)
 
     @classmethod
-    def from_cone(cls, lon, lat, radius, degrees=True, steps=16.0):
+    def from_cone(cls, lon, lat, radius, degrees=True, steps=16):
         r"""
         Create a new `_SingleSphericalPolygon` from a cone (otherwise known
         as a "small circle") defined using (*lon*, *lat*, *radius*).

--- a/spherical_geometry/tests/test_util.py
+++ b/spherical_geometry/tests/test_util.py
@@ -8,7 +8,8 @@ ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
 def get_point_set(density=25):
     points = []
     for i in np.linspace(-85, 85, density, True):
-        for j in np.linspace(-180, 180, np.cos(np.deg2rad(i)) * density):
+        adjusted_density = int(np.cos(np.deg2rad(i)) * density)
+        for j in np.linspace(-180, 180, adjusted_density):
             points.append([j, i])
     points = np.asarray(points)
     return np.dstack(vector.radec_to_vector(points[:,0], points[:,1]))[0]


### PR DESCRIPTION
The numpy function linspace computes an evenly spaced array of values. In the current version of numpy it checks if the number of steps is an integer.
Method from_code computes a spherical polygon representing the intersection of a cone with the unit sphere. The number of steps used in computing the pyramid approximating the cone had a default value that was a float. That value was used when calling linspace, resulting in an error. So the value has been changed from a float to an integer.
Get_point_set is a utility function used in testing. It covers an ra/dec box in a grid of points. The number of points is less at higher latitudes, multiplied by the cosine of the declination. This number is passed to linspace, also triggering an error. This number is now converted to an integer before calling linspace.

EDIT: Fix #103