### PR TITLE
Rewrite is_clockwise test and other changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.0.13'
+VERSION = '1.1.0'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -67,7 +67,7 @@ class Graph:
         def __repr__(self):
             return "Node(%s %d)" % (str(self._point), len(self._edges))
 
-        def equals(self, other, thres=2e-8):
+        def equals(self, other, thresh=1.e-9):
             """
             Returns `True` if the location of this and the *other*
             `~Graph.Node` are the same.
@@ -83,7 +83,8 @@ class Graph:
                 empirical test cases. Relative threshold based on
                 the actual sizes of polygons is not implemented.
             """
-            return np.array_equal(self._point, other._point)
+            return great_circle_arc.same_point(self._point, other._point,
+                                               tol=thresh)
 
 
     class Edge:
@@ -475,7 +476,7 @@ class Graph:
         -------
         points : Nx3 array of (*x*, *y*, *z*) points
             This is a list of points outlining the union of the
-            polygons that were given to the constructor. 
+            polygons that were given to the constructor.
         """
         self._find_all_intersections()
         self._sanity_check("union - find all intersections")
@@ -520,7 +521,7 @@ class Graph:
         else:
             polygons = list(self._source_polygons)
         return polygons
-    
+
     def _remove_cut_lines(self):
         """
         Removes any cutlines that may already have existed in the
@@ -567,7 +568,7 @@ class Graph:
             if len(A._edges) == 3 and len(B._edges) == 3:
                 cut_lines.append(edge)
                 changed = True
-                
+
         for edge in cut_lines:
             if edge in self._edges:
                 self._remove_edge(edge)
@@ -717,7 +718,7 @@ class Graph:
             if edge._count >= 1:
                 self._remove_edge(edge)
                 changed = True
-                
+
         changed = self._remove_orphaned_nodes() or changed
         return changed
 
@@ -761,7 +762,7 @@ class Graph:
             if edge._nodes[0].equals(edge._nodes[1]):
                 removals.append(edge)
                 changed = True
- 
+
         for edge in removals:
             if edge in self._edges:
                 self._remove_edge(edge)
@@ -868,7 +869,7 @@ class Graph:
                     points.append(node._point)
                     break
 
-            polygon = mpolygon._SingleSphericalPolygon(points, auto_orient=True)
+            polygon = mpolygon._SingleSphericalPolygon(points)
             polygons.append(polygon)
 
         return polygons

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -80,6 +80,10 @@ def triple_product(A, B, C):
     return inner1d(C, _fast_cross(A, B))
 
 
+if HAS_C_UFUNCS:
+    triple_product = math_util.triple_product
+
+
 def same_point(A, B, tol=1.0e-9):
     r"""
     Returns true if two points, or arrays of points considered pairwise

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -13,6 +13,8 @@ section of those circles between two points on the unit sphere.
 
 from __future__ import with_statement, division, absolute_import, unicode_literals
 
+import math
+
 # THIRD-PARTY
 import numpy as np
 
@@ -29,11 +31,8 @@ if HAS_C_UFUNCS:
 else:
     from numpy.core.umath_tests import inner1d
 
-
-
 __all__ = ['angle', 'intersection', 'intersects', 'intersects_point',
            'length', 'midpoint', 'interpolate']
-
 
 def _fast_cross(a, b):
     """
@@ -75,6 +74,39 @@ if HAS_C_UFUNCS:
     def _cross_and_normalize(A, B):
         with np.errstate(invalid='ignore'):
             return math_util.cross_and_norm(A, B)
+
+
+def triple_product(A, B, C):
+    return inner1d(C, _fast_cross(A, B))
+
+
+def same_point(A, B, tol=1.0e-9):
+    r"""
+    Returns true if two points, or arrays of points considered pairwise
+    are close enough to be considered the same point
+
+    Parameters
+    ----------
+    A, B : (*x*, *y*, *z*) triples or Nx3 arrays of triples
+
+    tol : If distance between two points is < tol (in radians), they are
+          considered the same
+    """
+    return inner1d(A, B) >= math.cos(tol)
+
+def same_arc(A, B, C, tol=1.0e-9):
+    r"""
+    Returns true if C is close enough to be considered to be on the
+    same great circle arc as A and B. This does not test if C is
+    between A and B.
+
+    Parameters
+    ----------
+    A, B: Endpoints of the arc
+
+    C:    Point which may lie on the arc
+    """
+    return abs(triple_product(A, B, C)) <= math.sin(tol)
 
 
 def intersection(A, B, C, D):

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -323,7 +323,7 @@ class _SingleSphericalPolygon(object):
 
     def _contains_point(self, point, P, r):
         point = np.asanyarray(point)
-        if np.array_equal(r, point):
+        if great_circle_arc.same_point(r, point):
             return True
 
         intersects = great_circle_arc.intersects(P[:-1], P[1:], r, point)

--- a/spherical_geometry/src/math_util.c
+++ b/spherical_geometry/src/math_util.c
@@ -392,6 +392,52 @@ static void * cross_and_norm_data[] = { (void *)NULL };
 static char cross_and_norm_signatures[] = { PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE };
 
 /*///////////////////////////////////////////////////////////////////////////
+  triple_product
+*/
+
+char *triple_product_signature = "(i),(i),(i)->()";
+
+/*
+ * Finds the triple_product at *B* between *A*, *B*,  and *C*.
+ */
+static void
+DOUBLE_triple_product(char **args, intp *dimensions, intp *steps, void *NPY_UNUSED(func))
+{
+    qd A[3];
+    qd B[3];
+    qd C[3];
+
+    qd ABX[3];
+    qd prod;
+
+    unsigned int old_cw;
+
+    INIT_OUTER_LOOP_4
+    intp is1=steps[0], is2=steps[1], is3=steps[2];
+
+    fpu_fix_start(&old_cw);
+
+    BEGIN_OUTER_LOOP_4
+        char *ip1=args[0], *ip2=args[1], *ip3=args[2], *op=args[3];
+
+        load_point_qd(ip1, is1, A);
+        load_point_qd(ip2, is2, B);
+        load_point_qd(ip3, is3, C);
+
+        cross_qd(A, B, ABX);
+        dot_qd(ABX, C, &prod);
+
+        *(double *)op = prod.x[0];
+    END_OUTER_LOOP
+
+    fpu_fix_end(&old_cw);
+}
+
+static PyUFuncGenericFunction triple_product_functions[] = { DOUBLE_triple_product };
+static void * triple_product_data[] = { (void *)NULL };
+static char triple_product_signatures[] = { PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE, PyArray_DOUBLE };
+
+/*///////////////////////////////////////////////////////////////////////////
   intersection
 */
 
@@ -730,6 +776,16 @@ addUfuncs(PyObject *dictionary) {
         "     \"(i),(i)->(i)\" \n",
         0, cross_and_norm_signature);
     PyDict_SetItemString(dictionary, "cross_and_norm", f);
+    Py_DECREF(f);
+
+    f = PyUFunc_FromFuncAndDataAndSignature(
+        triple_product_functions, triple_product_data, triple_product_signatures, 2, 3, 1,
+        PyUFunc_None, "triple_product",
+        "Calculate the triple_product between A, B and C.\n" \
+        "     \"(i),(i),(i)->()\" \n",
+        0, triple_product_signature);
+
+    PyDict_SetItemString(dictionary, "triple_product", f);
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(


### PR DESCRIPTION
This update rewrites the is_clockwise test in polygon.py. A number of other changes to the package follow from that change. The motivation was a test case where a user created a plygon whose vertices fall on lines of constant latitude and longitude. Lines of constant longitude are great circles, but lines of constant latitude are not, except for the equator. Since spherical polygon sides are great circles, this creates a scalloped polygon with a mix of convex and concave angles. The previous is_clockwise test incorrectly handled this kind of polygon. It also caused errors in the calculation of the inside point in the case none was specified when creating a spherical polygon.
    
The new code in is_clockwise calculates whether the two vectors forming the sides of a vertex and the vertex vector form a left handed or right handed system. This depends on the order the two sides are traversed. One way will give a right handed system and the opposite a left handed system. The handedness is given by the sign of the scalar triple product of the three vectors. Summing the polygon is ordered counter-clockwise. If left-handed, the polygon is ordered clockwise.

One consequence of this change is that now the area of a polygon is always a positive number between zero and four pi. There are no more negative areas. This is because the re-orientation of polygons means that the orientation never disagrees with the location of the inside point.

Debugging this problem has uncovered another problem in the package. The intersection code does not correctly handle the case where two intersecting arcs are co-linear. This will be fixed in another update.