### PR TITLE
Revised code for choosing between edges when tracing polygons

### DIFF
--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -323,7 +323,7 @@ class _SingleSphericalPolygon(object):
 
     def _contains_point(self, point, P, r):
         point = np.asanyarray(point)
-        if great_circle_arc.same_point(r, point):
+        if np.array_equal(r, point):
             return True
 
         intersects = great_circle_arc.intersects(P[:-1], P[1:], r, point)
@@ -473,12 +473,10 @@ class _SingleSphericalPolygon(object):
         if len(self._points) < 3:
             return np.array(0.0)
 
-        points = self._points
-        angles = np.hstack([
-            great_circle_arc.angle(
-                points[:-2], points[1:-1], points[2:], degrees=False),
-            great_circle_arc.angle(
-                points[-2], points[0], points[1], degrees=False)])
+        points = np.vstack((self._points, self._points[1]))
+        angles = great_circle_arc.angle(points[:-2], points[1:-1],
+                                        points[2:], degrees=False)
+
         return np.sum(angles) - (len(angles) - 2) * np.pi
 
     def union(self, other):


### PR DESCRIPTION
When taking the union or intersection of two polygons, the result is a
set of edges. The code then traces a closed path through the edges one
or more times to construct yje polygons. There are cases where more
than one edge is connected to a a previous edge. In this case we want
to choose an edge that does no create a self-intersecting
polygon. There was an error in the code which caused the first edge to
always be selected. The new code choose an edge which makes an angle
with the previous edge that is midmost of the choices. This avoids
choosing an edge that makes a straight line with the previous edge.

I also removed use of same_arc for the present, which seems to have a
rounding problem.