### PR TITLE
Better handling for self-intersecting polygons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
+	- PIP_DEPENDENCIES='pytest-astropy'
     matrix:
         - SETUP_CMD='egg_info'
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.1.0'
+VERSION = '1.2.0'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -14,6 +14,7 @@ section of those circles between two points on the unit sphere.
 from __future__ import with_statement, division, absolute_import, unicode_literals
 
 import math
+from .vector import two_d
 
 # THIRD-PARTY
 import numpy as np
@@ -25,6 +26,7 @@ try:
     HAS_C_UFUNCS = True
 except ImportError:
     HAS_C_UFUNCS = False
+
 
 if HAS_C_UFUNCS:
     inner1d = math_util.inner1d
@@ -63,7 +65,7 @@ def _cross_and_normalize(A, B):
     T = _fast_cross(A, B)
     # Normalization
     l = np.sqrt(np.sum(T ** 2, axis=-1))
-    l = np.expand_dims(l, 2)
+    l = two_d(l)
     # Might get some divide-by-zeros, but we don't care
     with np.errstate(invalid='ignore'):
         TN = T / l
@@ -82,35 +84,6 @@ def triple_product(A, B, C):
 
 if HAS_C_UFUNCS:
     triple_product = math_util.triple_product
-
-
-def same_point(A, B, tol=1.0e-9):
-    r"""
-    Returns true if two points, or arrays of points considered pairwise
-    are close enough to be considered the same point
-
-    Parameters
-    ----------
-    A, B : (*x*, *y*, *z*) triples or Nx3 arrays of triples
-
-    tol : If distance between two points is < tol (in radians), they are
-          considered the same
-    """
-    return inner1d(A, B) >= math.cos(tol)
-
-def same_arc(A, B, C, tol=1.0e-9):
-    r"""
-    Returns true if C is close enough to be considered to be on the
-    same great circle arc as A and B. This does not test if C is
-    between A and B.
-
-    Parameters
-    ----------
-    A, B: Endpoints of the arc
-
-    C:    Point which may lie on the arc
-    """
-    return abs(triple_product(A, B, C)) <= math.sin(tol)
 
 
 def intersection(A, B, C, D):
@@ -193,7 +166,7 @@ def intersection(A, B, C, D):
     s += np.sign(inner1d(_fast_cross(CDX, C), T))
     s += np.sign(inner1d(_fast_cross(D, CDX), T))
     if T_ndim > 1:
-        s = np.expand_dims(s, 2)
+        s = two_d(s)
 
     cross = np.where(s == -4, -T, np.where(s == 4, T, np.nan))
 
@@ -205,7 +178,7 @@ def intersection(A, B, C, D):
               np.all(B == C, axis=-1) |
               np.all(B == D, axis=-1))
 
-    equals = np.expand_dims(equals, 2)
+    equals = two_d(equals)
 
     return np.where(equals, np.nan, cross)
 
@@ -248,8 +221,8 @@ def length(A, B, degrees=True):
         B2 = B ** 2.0
         Bl = np.sqrt(np.sum(B2, axis=-1))
 
-        A = A / np.expand_dims(Al, 2)
-        B = B / np.expand_dims(Bl, 2)
+        A = A / two_d(Al)
+        B = B / two_d(Bl)
 
         dot = inner1d(A, B)
         dot = np.clip(dot, -1.0, 1.0)
@@ -388,7 +361,7 @@ def midpoint(A, B):
     P = (A + B) / 2.0
     # Now normalize...
     l = np.sqrt(np.sum(P * P, axis=-1))
-    l = np.expand_dims(l, 2)
+    l = two_d(l)
     return P / l
 
 

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -35,8 +35,7 @@ class _SingleSphericalPolygon(object):
         Parameters
         ----------
         points : An Nx3 array of (*x*, *y*, *z*) triples in vector space
-            These points define the boundary of the polygon.  It must
-            be "closed", i.e., the last point is the same as the first.
+            These points define the boundary of the polygon.
 
             It may contain zero points, in which it defines the null
             polygon.  It may not contain one, two or three points.
@@ -337,8 +336,7 @@ class _SingleSphericalPolygon(object):
     def _find_new_inside(self):
         """
         Finds an acceptable inside point inside of *points* that is
-        also inside of *polygons*.  Used by the intersection
-        algorithm and the area computation.
+        also inside of *polygons*.
         """
         npoints = len(self._points)
         if npoints > 4:
@@ -475,18 +473,14 @@ class SphericalPolygon(object):
 
                - An Nx3 array of (*x*, *y*, *z*) triples in Cartesian
                  space.  These points define the boundary of the
-                 polygon.  It must be "closed", i.e., the last point
-                 is the same as the first.
+                 polygon.
 
                  It may contain zero points, in which it defines the
-                 null polygon.  It may not contain one, two or three
-                 points.  Four points are needed to define a triangle,
-                 since the polygon must be closed.
+                 null polygon.  It may not contain one or two points.
 
         inside : An (*x*, *y*, *z*) triple, optional
             If *init* is an array of points, this point must be inside
-            the polygon.  If not provided, the mean of the points will
-            be used.
+            the polygon.  If it is not provided, one will be created.
 
         """
         from . import graph
@@ -597,8 +591,7 @@ class SphericalPolygon(object):
         ----------
         lon, lat : 1-D arrays of the same length
             The vertices of the polygon in longitude and
-            latitude.  It must be \"closed\", i.e., that is, the
-            last point is the same as the first.
+            latitude.
 
         center : (*lon*, *lat*) pair, optional
             A point inside of the polygon to define its inside.
@@ -652,7 +645,7 @@ class SphericalPolygon(object):
 
         Returns
         -------
-        polygon : `_SingleSphericalPolygon` object
+        polygon : `SphericalPolygon` object
         """
         u, v, w = vector.lonlat_to_vector(lon, lat, degrees=degrees)
         if degrees:
@@ -705,7 +698,7 @@ class SphericalPolygon(object):
 
         Returns
         -------
-        polygon : `_SingleSphericalPolygon` object
+        polygon : `SphericalPolygon` object
         """
         from astropy import wcs as pywcs
         from astropy.io import fits

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -82,8 +82,6 @@ class _SingleSphericalPolygon(object):
             if self.contains_point(new_inside) != self.is_clockwise():
                 self._points = points[::-1]
 
-        # TODO: Detect self-intersection and fix
-
     def __copy__(self):
         return deepcopy(self)
 
@@ -693,6 +691,9 @@ class SphericalPolygon(object):
         return deepcopy(self)
 
     copy = __copy__
+
+    def __len__(self):
+        return len(self._polygons)
 
     def iter_polygons_flat(self):
         """

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -323,7 +323,7 @@ class _SingleSphericalPolygon(object):
 
     def _contains_point(self, point, P, r):
         point = np.asanyarray(point)
-        if great_circle_arc.same_point(r, point):
+        if np.array_equal(r, point):
             return True
 
         intersects = great_circle_arc.intersects(P[:-1], P[1:], r, point)
@@ -473,12 +473,10 @@ class _SingleSphericalPolygon(object):
         if len(self._points) < 3:
             return np.array(0.0)
 
-        points = self._points
-        angles = np.hstack([
-            great_circle_arc.angle(
-                points[:-2], points[1:-1], points[2:], degrees=False),
-            great_circle_arc.angle(
-                points[-2], points[0], points[1], degrees=False)])
+        points = np.vstack((self._points, self._points[1]))
+        angles = great_circle_arc.angle(points[:-2], points[1:-1],
+                                        points[2:], degrees=False)
+
         return np.sum(angles) - (len(angles) - 2) * np.pi
 
     def union(self, other):

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -37,30 +37,6 @@ def test_normalize_unit_vector():
         l = np.sqrt(np.sum(xyzn * xyzn, axis=-1))
         assert_almost_equal(l, 1.0)
 
-def test_same_point():
-    angle = 1.0
-    A = np.asarray([1.0, 0.0, 0.0])
-    B = []
-    for i in range(20):
-        B.append([math.cos(angle), math.sin(angle), 0])
-        angle = angle / 10.0
-    B = np.asanyarray(B)
-    same = great_circle_arc.same_point(A, B, tol=2.0e-8)
-    assert np.all(same[8:])
-
-def test_same_arc():
-    angle = 1.0
-    root2 = 0.5 * math.sqrt(2.0)
-    A = np.asarray([root2, 0.0, root2])
-    B = np.asarray([0.0, 0.0, 1.0])
-    C = []
-    for i in range(20):
-        C.append([math.cos(angle), math.sin(angle), 0])
-        angle = angle / 10.0
-    C = np.asarray(C)
-    same = great_circle_arc.same_arc(A, B, C, tol=2.0e-8)
-    assert np.all(same[8:])
-
 def test_lonlat_to_vector():
     npx, npy, npz = vector.lonlat_to_vector(np.arange(-360, 360, 1), 90)
     assert_almost_equal(npx, 0.0)
@@ -191,7 +167,7 @@ def test_overlap():
             point[0] += offset
             points.append(np.asarray(vector.lonlat_to_vector(point[0],
                                                              point[1])))
-        poly = polygon.SphericalPolygon(points, auto_close=True)
+        poly = polygon.SphericalPolygon(points)
         return poly
 
     first_poly = build_polygon(0.0)

--- a/spherical_geometry/vector.py
+++ b/spherical_geometry/vector.py
@@ -19,9 +19,18 @@ except ImportError:
     HAS_C_UFUNCS = False
 
 
-__all__ = ['lonlat_to_vector', 'vector_to_lonlat', 'normalize_vector',
-           'radec_to_vector', 'vector_to_radec', 'rotate_around']
+__all__ = ['two_d', 'lonlat_to_vector', 'vector_to_lonlat',
+           'normalize_vector', 'radec_to_vector', 'vector_to_radec',
+           'rotate_around']
 
+def two_d(vec):
+    """
+    Reshape a one dimensional vector so it has a second dimension
+    """
+    shape = list(vec.shape)
+    shape.append(1)
+    shape = tuple(shape)
+    return np.reshape(vec, shape)
 
 def lonlat_to_vector(lon, lat, degrees=True):
     r"""
@@ -182,7 +191,7 @@ def normalize_vector(xyz, output=None):
 
     l = np.sqrt(np.sum(xyz * xyz, axis=-1))
 
-    output = xyz / np.expand_dims(l, 2)
+    output = xyz / two_d(l)
 
     return output
 
@@ -255,4 +264,4 @@ def equal_area_proj(points):
         Y = \\sqrt{\\frac{2}{1-z}}y
     """
     scale = np.sqrt(2.0 / (1.0 - points[..., 2]))
-    return np.expand_dims(scale, 2) * points[:, 0:2]
+    return two_d(scale) * points[:, 0:2]


### PR DESCRIPTION
The last update introduced support for creating polygons from self-intersecting polygons. It added code to check for intersections and generate the list of simple, disjoint polygons. However, not all
the methods that create new polygons called the checking code. This update modifies the polygon creating methods to call the new code, which is in the __init__ method of SpherivalPolygon.

Testing found that the intersection checking code could create unclosed polygons, where the first and final points are not the same. So the code that closes a polygon is now always called and the option which used to control it, auto_close has been removed. Since this is a change to the interface, the version number has been changed to 1.2.

The test suite reported that the numpy function expand_dims was no longer supporting the way the spherical geometry package was using it, adding a second dimension of length one to a one dimensional vector. I added a new function, two_d to vector.py which calls numpy reshape and does the same work expand_dims used to do.

I deleted the functions same_point and same_arc, as they were not being used by the other code and sometimes generated wrong results. It looks like the quad precision math routines has removed the need to check for points that are nearly the same but not identical.