### PR TITLE
Fix for self-intersecting polygons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
+	- PIP_DEPENDENCIES='pytest-astropy'
     matrix:
         - SETUP_CMD='egg_info'
 

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -14,6 +14,7 @@ section of those circles between two points on the unit sphere.
 from __future__ import with_statement, division, absolute_import, unicode_literals
 
 import math
+from .vector import two_d
 
 # THIRD-PARTY
 import numpy as np
@@ -25,6 +26,7 @@ try:
     HAS_C_UFUNCS = True
 except ImportError:
     HAS_C_UFUNCS = False
+
 
 if HAS_C_UFUNCS:
     inner1d = math_util.inner1d
@@ -63,7 +65,7 @@ def _cross_and_normalize(A, B):
     T = _fast_cross(A, B)
     # Normalization
     l = np.sqrt(np.sum(T ** 2, axis=-1))
-    l = np.expand_dims(l, 2)
+    l = two_d(l)
     # Might get some divide-by-zeros, but we don't care
     with np.errstate(invalid='ignore'):
         TN = T / l
@@ -82,35 +84,6 @@ def triple_product(A, B, C):
 
 if HAS_C_UFUNCS:
     triple_product = math_util.triple_product
-
-
-def same_point(A, B, tol=1.0e-9):
-    r"""
-    Returns true if two points, or arrays of points considered pairwise
-    are close enough to be considered the same point
-
-    Parameters
-    ----------
-    A, B : (*x*, *y*, *z*) triples or Nx3 arrays of triples
-
-    tol : If distance between two points is < tol (in radians), they are
-          considered the same
-    """
-    return inner1d(A, B) >= math.cos(tol)
-
-def same_arc(A, B, C, tol=1.0e-9):
-    r"""
-    Returns true if C is close enough to be considered to be on the
-    same great circle arc as A and B. This does not test if C is
-    between A and B.
-
-    Parameters
-    ----------
-    A, B: Endpoints of the arc
-
-    C:    Point which may lie on the arc
-    """
-    return abs(triple_product(A, B, C)) <= math.sin(tol)
 
 
 def intersection(A, B, C, D):
@@ -193,7 +166,7 @@ def intersection(A, B, C, D):
     s += np.sign(inner1d(_fast_cross(CDX, C), T))
     s += np.sign(inner1d(_fast_cross(D, CDX), T))
     if T_ndim > 1:
-        s = np.expand_dims(s, 2)
+        s = two_d(s)
 
     cross = np.where(s == -4, -T, np.where(s == 4, T, np.nan))
 
@@ -205,7 +178,7 @@ def intersection(A, B, C, D):
               np.all(B == C, axis=-1) |
               np.all(B == D, axis=-1))
 
-    equals = np.expand_dims(equals, 2)
+    equals = two_d(equals)
 
     return np.where(equals, np.nan, cross)
 
@@ -248,8 +221,8 @@ def length(A, B, degrees=True):
         B2 = B ** 2.0
         Bl = np.sqrt(np.sum(B2, axis=-1))
 
-        A = A / np.expand_dims(Al, 2)
-        B = B / np.expand_dims(Bl, 2)
+        A = A / two_d(Al)
+        B = B / two_d(Bl)
 
         dot = inner1d(A, B)
         dot = np.clip(dot, -1.0, 1.0)
@@ -388,7 +361,7 @@ def midpoint(A, B):
     P = (A + B) / 2.0
     # Now normalize...
     l = np.sqrt(np.sum(P * P, axis=-1))
-    l = np.expand_dims(l, 2)
+    l = two_d(l)
     return P / l
 
 

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -30,13 +30,12 @@ class _SingleSphericalPolygon(object):
     therefore we need a way of specifying which is which.
     """
 
-    def __init__(self, points, inside=None, auto_close=False):
+    def __init__(self, points, inside=None):
         r"""
         Parameters
         ----------
         points : An Nx3 array of (*x*, *y*, *z*) triples in vector space
-            These points define the boundary of the polygon.  It must
-            be "closed", i.e., the last point is the same as the first.
+            These points define the boundary of the polygon.
 
             It may contain zero points, in which it defines the null
             polygon.  It may not contain one, two or three points.
@@ -47,9 +46,6 @@ class _SingleSphericalPolygon(object):
             This point must be inside the polygon.  If not provided, an
             interior point will be calculated
 
-        auto_close : bool, optional
-            If True, and the input polygon is not closed,
-            add the initial point to the polygon.
 
         """
         if len(points) == 0:
@@ -59,14 +55,12 @@ class _SingleSphericalPolygon(object):
             self._points = np.asanyarray(points)
             return
 
-        if auto_close:
+        if not np.array_equal(points[0], points[-1]):
             points = list(points[:])
             points.append(points[0])
 
         if len(points) < 3:
             raise ValueError("Polygon made of too few points")
-        else:
-            assert np.array_equal(points[0], points[-1]), 'Polygon is not closed'
 
         self._points = points = np.asanyarray(points)
         new_inside = self._find_new_inside()
@@ -148,176 +142,6 @@ class _SingleSphericalPolygon(object):
             return np.array([])
         return vector.vector_to_lonlat(self.points[:,0], self.points[:,1],
                                       self.points[:,2], degrees=True)
-
-    @classmethod
-    def from_lonlat(cls, lon, lat, center=None, degrees=True,
-                    auto_close=False):
-        r"""
-        Create a new `SphericalPolygon` from a list of (*longitude*, *latitude*)
-        points.
-
-        Parameters
-        ----------
-        lon, lat : 1-D arrays of the same length
-            The vertices of the polygon in longitude and
-            latitude.  It must be \"closed\", i.e., that is, the
-            last point is the same as the first.
-
-        center : (*lon*, *lat*) pair, optional
-            A point inside of the polygon to define its inside.  If no
-            *center* point is provided, the mean of the polygon's
-            points in vector space will be used.  That approach may
-            not work for concave polygons.
-
-        degrees : bool, optional
-            If `True`, (default) *lon* and *lat* are in decimal degrees,
-            otherwise in radians.
-
-        auto_close : bool, optional
-            If True, input polygon is not closed, add the initial lon, lat pair
-            to the polygon.
-
-        Returns
-        -------
-        polygon : `SphericalPolygon` object
-        """
-        # Convert to Cartesian
-        x, y, z = vector.lonlat_to_vector(lon, lat, degrees=degrees)
-
-        points = np.dstack((x, y, z))[0]
-
-        if center is None:
-            center = points.mean(axis=0)
-            vector.normalize_vector(center, output=center)
-        else:
-            center = vector.lonlat_to_vector(*center, degrees=degrees)
-
-        return cls(points, center, auto_close=auto_close)
-
-    @classmethod
-    def from_cone(cls, lon, lat, radius, degrees=True, steps=16):
-        r"""
-        Create a new `_SingleSphericalPolygon` from a cone (otherwise known
-        as a "small circle") defined using (*lon*, *lat*, *radius*).
-
-        The cone is not represented as an ideal circle on the sphere,
-        but as a series of great circle arcs.  The resolution of this
-        conversion can be controlled using the *steps* parameter.
-
-        Parameters
-        ----------
-        lon, lat : float scalars
-            This defines the center of the cone
-
-        radius : float scalar
-            The radius of the cone
-
-        degrees : bool, optional
-            If `True`, (default) *lon*, *lat* and *radius* are in
-            decimal degrees, otherwise in radians.
-
-        steps : int, optional
-            The number of steps to use when converting the small
-            circle to a polygon.
-
-        Returns
-        -------
-        polygon : `_SingleSphericalPolygon` object
-        """
-        u, v, w = vector.lonlat_to_vector(lon, lat, degrees=degrees)
-        if degrees:
-            radius = np.deg2rad(radius)
-
-        # Get an arbitrary perpendicular vector.  This be be obtained
-        # by crossing (u, v, w) with any unit vector that is not itself.
-        which_min = np.argmin([u*u, v*v, w*w])
-        if which_min == 0:
-            perp = np.cross([u, v, w], [1., 0., 0.])
-        elif which_min == 1:
-            perp = np.cross([u, v, w], [0., 1., 0.])
-        else:
-            perp = np.cross([u, v, w], [0., 0., 1.])
-        perp = vector.normalize_vector(perp)
-
-        # Rotate by radius around the perpendicular vector to get the
-        # "pen"
-        x, y, z = vector.rotate_around(
-            u, v, w, perp[0], perp[1], perp[2], radius, degrees=False)
-
-        # Then rotate the pen around the center point all 360 degrees
-        C = np.linspace(0, np.pi * 2.0, steps)
-        # Ensure that the first and last elements are exactly the
-        # same.  2π should equal 0, but with rounding error that isn't
-        # always the case.
-        C[-1] = 0
-        C = C[::-1]
-        X, Y, Z = vector.rotate_around(x, y, z, u, v, w, C, degrees=False)
-
-        return cls(np.dstack((X, Y, Z))[0], (u, v, w))
-
-    @classmethod
-    def from_wcs(cls, fitspath, steps=1, crval=None):
-        r"""
-        Create a new `_SingleSphericalPolygon` from the footprint of a FITS
-        WCS specification.
-
-        This method requires having `astropy <http://astropy.org>`__
-        installed.
-
-        Parameters
-        ----------
-        fitspath : path to a FITS file, `astropy.io.fits.Header`, or `astropy.wcs.WCS`
-            Refers to a FITS header containing a WCS specification.
-
-        steps : int, optional
-            The number of steps along each edge to convert into
-            polygon edges.
-
-        Returns
-        -------
-        polygon : `_SingleSphericalPolygon` object
-        """
-        from astropy import wcs as pywcs
-        from astropy.io import fits
-
-        if isinstance(fitspath, fits.Header):
-            header = fitspath
-            wcs = pywcs.WCS(header)
-        elif isinstance(fitspath, pywcs.WCS):
-            wcs = fitspath
-        else:
-            wcs = pywcs.WCS(fitspath)
-        if crval is not None:
-            wcs.wcs.crval = crval
-        xa, ya = [wcs._naxis1, wcs._naxis2]
-
-        length = steps * 4 + 1
-        X = np.empty(length)
-        Y = np.empty(length)
-
-        # Now define each of the 4 edges of the quadrilateral
-        X[0      :steps  ] = np.linspace(1, xa, steps, False)
-        Y[0      :steps  ] = 1
-        X[steps  :steps*2] = xa
-        Y[steps  :steps*2] = np.linspace(1, ya, steps, False)
-        X[steps*2:steps*3] = np.linspace(xa, 1, steps, False)
-        Y[steps*2:steps*3] = ya
-        X[steps*3:steps*4] = 1
-        Y[steps*3:steps*4] = np.linspace(ya, 1, steps, False)
-        X[-1]              = 1
-        Y[-1]              = 1
-
-        # Use wcslib to convert to (lon, lat)
-        lon, lat = wcs.all_pix2world(X, Y, 1)
-
-        # Convert to Cartesian
-        x, y, z = vector.lonlat_to_vector(lon, lat)
-
-        # Calculate an inside point
-        lon, lat = wcs.all_pix2world(xa / 2.0, ya / 2.0, 1)
-        xc, yc, zc = vector.lonlat_to_vector(lon, lat)
-
-        return cls(np.dstack((x, y, z))[0], (xc, yc, zc))
 
     def _contains_point(self, point, P, r):
         point = np.asanyarray(point)
@@ -512,8 +336,7 @@ class _SingleSphericalPolygon(object):
     def _find_new_inside(self):
         """
         Finds an acceptable inside point inside of *points* that is
-        also inside of *polygons*.  Used by the intersection
-        algorithm and the area computation.
+        also inside of *polygons*.
         """
         npoints = len(self._points)
         if npoints > 4:
@@ -640,7 +463,7 @@ class SphericalPolygon(object):
     This class contains a list of disjoint closed polygons.
     """
 
-    def __init__(self, init, inside=None, auto_close=False):
+    def __init__(self, init, inside=None):
         r"""
         Parameters
         ----------
@@ -650,23 +473,14 @@ class SphericalPolygon(object):
 
                - An Nx3 array of (*x*, *y*, *z*) triples in Cartesian
                  space.  These points define the boundary of the
-                 polygon.  It must be "closed", i.e., the last point
-                 is the same as the first.
+                 polygon.
 
                  It may contain zero points, in which it defines the
-                 null polygon.  It may not contain one, two or three
-                 points.  Four points are needed to define a triangle,
-                 since the polygon must be closed.
+                 null polygon.  It may not contain one or two points.
 
         inside : An (*x*, *y*, *z*) triple, optional
             If *init* is an array of points, this point must be inside
-            the polygon.  If not provided, the mean of the points will
-            be used.
-
-        auto_close : bool, optional
-            If True, input polygon is not closed, add the initial point
-            to the polygon.
-
+            the polygon.  If it is not provided, one will be created.
 
         """
         from . import graph
@@ -677,8 +491,7 @@ class SphericalPolygon(object):
             self._polygons = tuple(init)
             return
 
-        self._polygons = (_SingleSphericalPolygon(init, inside,
-                                                  auto_close=auto_close),)
+        self._polygons = (_SingleSphericalPolygon(init, inside),)
 
         polygons = []
         for polygon in self.iter_polygons_flat():
@@ -765,98 +578,49 @@ class SphericalPolygon(object):
         for polygon in self.iter_polygons_flat():
             yield polygon.to_lonlat()
 
-    def to_radec(self):
-        """
-        Convert the `SphericalPolygon` footprint to right ascension and
-        declination coordinates.
-
-        Returns
-        -------
-        polyons : iterator
-            Each element in the iterator is a tuple of the form (*lon*,
-            *lat*), where each is an array of points.
-        """
-        yield self.to_lonlat()
+    # to_ra_dec is an alias for to_lonlat
+    to_radec = to_lonlat
 
     @classmethod
-    def from_lonlat(cls, lon, lat, center=None, degrees=True,
-                    auto_close=False):
+    def from_lonlat(cls, lon, lat, center=None, degrees=True):
         r"""
-        Create a new `SphericalPolygon` from a list of (*lon*, *lat*)
+        Create a new `SphericalPolygon` from a list of (*longitude*, *latitude*)
         points.
 
         Parameters
         ----------
         lon, lat : 1-D arrays of the same length
             The vertices of the polygon in longitude and
-            latitude.  It must be \"closed\", i.e., that is, the
-            last point is the same as the first.
+            latitude.
 
         center : (*lon*, *lat*) pair, optional
-            A point inside of the polygon to define its inside.  If no
-            *center* point is provided, the mean of the polygon's
-            points in vector space will be used.  That approach may
-            not work for concave polygons.
+            A point inside of the polygon to define its inside.
 
         degrees : bool, optional
             If `True`, (default) *lon* and *lat* are in decimal degrees,
             otherwise in radians.
 
-        auto_close : bool, optional
-            If True, input polygon is not closed, add the initial ;pn, lat pair
-            to the polygon.
-
-
         Returns
         -------
         polygon : `SphericalPolygon` object
         """
-        return cls([
-            _SingleSphericalPolygon.from_lonlat(
-                lon, lat, center=center, degrees=degrees,
-                auto_close=auto_close)])
+        # Convert to Cartesian
+        x, y, z = vector.lonlat_to_vector(lon, lat, degrees=degrees)
 
-    @classmethod
-    def from_radec(cls, ra, dec, center=None, degrees=True,
-                   auto_close=False):
-        r"""
-        Create a new `SphericalPolygon` from a list of (*ra*, *dec*)
-        points.
+        points = np.dstack((x, y, z))[0]
 
-        Parameters
-        ----------
-        ra, dec : 1-D arrays of the same length
-            The vertices of the polygon in right ascension and
-            declination.  It must be \"closed\", i.e., that is, the
-            last point is the same as the first.
+        if center is not None:
+            center = vector.lonlat_to_vector(*center, degrees=degrees)
 
-        center : (*ra*, *dec*) pair, optional
-            A point inside of the polygon to define its inside.  If no
-            *center* point is provided, the mean of the polygon's
-            points in vector space will be used.  That approach may
-            not work for concave polygons.
+        return cls(points, center)
 
-        degrees : bool, optional
-            If `True`, (default) *ra* and *dec* are in decimal degrees,
-            otherwise in radians.
-
-        auto_close : bool, optional
-            If True, input polygon is not closed, add the initial ra, dec pair
-            to the polygon.
-
-        Returns
-        -------
-        polygon : `SphericalPolygon` object
-        """
-        return cls([
-            _SingleSphericalPolygon.from_lonlat(
-                ra, dec, center=center, degrees=degrees,
-                auto_close=auto_close)])
+    # from_radec is an alias for from_lon_lat
+    from_radec = from_lonlat
 
     @classmethod
     def from_cone(cls, lon, lat, radius, degrees=True, steps=16):
         r"""
-        Create a new `SphericalPolygon` from a cone (otherwise known
+        Create a new `_SingleSphericalPolygon` from a cone (otherwise known
         as a "small circle") defined using (*lon*, *lat*, *radius*).
 
         The cone is not represented as an ideal circle on the sphere,
@@ -883,14 +647,41 @@ class SphericalPolygon(object):
         -------
         polygon : `SphericalPolygon` object
         """
-        return cls([
-            _SingleSphericalPolygon.from_cone(
-                lon, lat, radius, degrees=degrees, steps=steps)])
+        u, v, w = vector.lonlat_to_vector(lon, lat, degrees=degrees)
+        if degrees:
+            radius = np.deg2rad(radius)
+
+        # Get an arbitrary perpendicular vector.  This be be obtained
+        # by crossing (u, v, w) with any unit vector that is not itself.
+        which_min = np.argmin([u*u, v*v, w*w])
+        if which_min == 0:
+            perp = np.cross([u, v, w], [1., 0., 0.])
+        elif which_min == 1:
+            perp = np.cross([u, v, w], [0., 1., 0.])
+        else:
+            perp = np.cross([u, v, w], [0., 0., 1.])
+        perp = vector.normalize_vector(perp)
+
+        # Rotate by radius around the perpendicular vector to get the
+        # "pen"
+        x, y, z = vector.rotate_around(
+            u, v, w, perp[0], perp[1], perp[2], radius, degrees=False)
+
+        # Then rotate the pen around the center point all 360 degrees
+        C = np.linspace(0, np.pi * 2.0, steps)
+        # Ensure that the first and last elements are exactly the
+        # same.  2π should equal 0, but with rounding error that isn't
+        # always the case.
+        C[-1] = 0
+        C = C[::-1]
+        X, Y, Z = vector.rotate_around(x, y, z, u, v, w, C, degrees=False)
+
+        return cls(np.dstack((X, Y, Z))[0], (u, v, w))
 
     @classmethod
     def from_wcs(cls, fitspath, steps=1, crval=None):
         r"""
-        Create a new `SphericalPolygon` from the footprint of a FITS
+        Create a new `_SingleSphericalPolygon` from the footprint of a FITS
         WCS specification.
 
         This method requires having `astropy <http://astropy.org>`__
@@ -909,9 +700,47 @@ class SphericalPolygon(object):
         -------
         polygon : `SphericalPolygon` object
         """
-        return cls([
-            _SingleSphericalPolygon.from_wcs(
-                fitspath, steps=steps, crval=crval)])
+        from astropy import wcs as pywcs
+        from astropy.io import fits
+
+        if isinstance(fitspath, fits.Header):
+            header = fitspath
+            wcs = pywcs.WCS(header)
+        elif isinstance(fitspath, pywcs.WCS):
+            wcs = fitspath
+        else:
+            wcs = pywcs.WCS(fitspath)
+        if crval is not None:
+            wcs.wcs.crval = crval
+        xa, ya = [wcs._naxis1, wcs._naxis2]
+
+        length = steps * 4 + 1
+        X = np.empty(length)
+        Y = np.empty(length)
+
+        # Now define each of the 4 edges of the quadrilateral
+        X[0      :steps  ] = np.linspace(1, xa, steps, False)
+        Y[0      :steps  ] = 1
+        X[steps  :steps*2] = xa
+        Y[steps  :steps*2] = np.linspace(1, ya, steps, False)
+        X[steps*2:steps*3] = np.linspace(xa, 1, steps, False)
+        Y[steps*2:steps*3] = ya
+        X[steps*3:steps*4] = 1
+        Y[steps*3:steps*4] = np.linspace(ya, 1, steps, False)
+        X[-1]              = 1
+        Y[-1]              = 1
+
+        # Use wcslib to convert to (lon, lat)
+        lon, lat = wcs.all_pix2world(X, Y, 1)
+
+        # Convert to Cartesian
+        x, y, z = vector.lonlat_to_vector(lon, lat)
+
+        # Calculate an inside point
+        lon, lat = wcs.all_pix2world(xa / 2.0, ya / 2.0, 1)
+        xc, yc, zc = vector.lonlat_to_vector(lon, lat)
+
+        return cls(np.dstack((x, y, z))[0], (xc, yc, zc))
 
     def contains_point(self, point):
         r"""

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -37,30 +37,6 @@ def test_normalize_unit_vector():
         l = np.sqrt(np.sum(xyzn * xyzn, axis=-1))
         assert_almost_equal(l, 1.0)
 
-def test_same_point():
-    angle = 1.0
-    A = np.asarray([1.0, 0.0, 0.0])
-    B = []
-    for i in range(20):
-        B.append([math.cos(angle), math.sin(angle), 0])
-        angle = angle / 10.0
-    B = np.asanyarray(B)
-    same = great_circle_arc.same_point(A, B, tol=2.0e-8)
-    assert np.all(same[8:])
-
-def test_same_arc():
-    angle = 1.0
-    root2 = 0.5 * math.sqrt(2.0)
-    A = np.asarray([root2, 0.0, root2])
-    B = np.asarray([0.0, 0.0, 1.0])
-    C = []
-    for i in range(20):
-        C.append([math.cos(angle), math.sin(angle), 0])
-        angle = angle / 10.0
-    C = np.asarray(C)
-    same = great_circle_arc.same_arc(A, B, C, tol=2.0e-8)
-    assert np.all(same[8:])
-
 def test_lonlat_to_vector():
     npx, npy, npz = vector.lonlat_to_vector(np.arange(-360, 360, 1), 90)
     assert_almost_equal(npx, 0.0)
@@ -191,7 +167,7 @@ def test_overlap():
             point[0] += offset
             points.append(np.asarray(vector.lonlat_to_vector(point[0],
                                                              point[1])))
-        poly = polygon.SphericalPolygon(points, auto_close=True)
+        poly = polygon.SphericalPolygon(points)
         return poly
 
     first_poly = build_polygon(0.0)

--- a/spherical_geometry/vector.py
+++ b/spherical_geometry/vector.py
@@ -19,9 +19,18 @@ except ImportError:
     HAS_C_UFUNCS = False
 
 
-__all__ = ['lonlat_to_vector', 'vector_to_lonlat', 'normalize_vector',
-           'radec_to_vector', 'vector_to_radec', 'rotate_around']
+__all__ = ['two_d', 'lonlat_to_vector', 'vector_to_lonlat',
+           'normalize_vector', 'radec_to_vector', 'vector_to_radec',
+           'rotate_around']
 
+def two_d(vec):
+    """
+    Reshape a one dimensional vector so it has a second dimension
+    """
+    shape = list(vec.shape)
+    shape.append(1)
+    shape = tuple(shape)
+    return np.reshape(vec, shape)
 
 def lonlat_to_vector(lon, lat, degrees=True):
     r"""
@@ -182,7 +191,7 @@ def normalize_vector(xyz, output=None):
 
     l = np.sqrt(np.sum(xyz * xyz, axis=-1))
 
-    output = xyz / np.expand_dims(l, 2)
+    output = xyz / two_d(l)
 
     return output
 
@@ -255,4 +264,4 @@ def equal_area_proj(points):
         Y = \\sqrt{\\frac{2}{1-z}}y
     """
     scale = np.sqrt(2.0 / (1.0 - points[..., 2]))
-    return np.expand_dims(scale, 2) * points[:, 0:2]
+    return two_d(scale) * points[:, 0:2]


### PR DESCRIPTION
The last update introduced support for creating polygons from self-intersecting polygons. It added code to check for intersections and generate the list of simple, disjoint polygons. However, not all
the methods that create new polygons called the checking code. This update modifies the polygon creating methods to call the new code, which is in the __init__ method of SpherivalPolygon.

Testing found that the intersection checking code could create unclosed polygons, where the first and final points are not the same. So the code that closes a polygon is now always called and the
option which used to control it, auto_close has been removed. Since this is a change to the interface, the version number has been changed to 1.2.

The test suite reported that the numpy function expand_dims was no longer supporting the way the spherical geometry package was using it, adding a second dimension of length one to a one dimensional vector. I added a new function, two_d to vector.py which calls numpy reshape and
does the same work expand_dims used to do.

I deleted the functions same_point and same_arc, as they were not being used by the other code and sometimes generated wrong results. It looks like the quad precision math routines has removed the need to check for points that are nearly the same but not identical.