### PR TITLE
Reliably compute interior point for union and intersection of polygons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.1.0'
+VERSION = '1.2.1'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
Previously the spherical astronomy package placed the interior point in the default location, the smaller portion of the sphere divided by the polygon's perimeter. The new code checks to see if this placement is correct and if it is not, inverts the polygon.