### PR TITLE
Improve self-intersection checks

### DIFF
--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -580,6 +580,17 @@ class SphericalPolygon(object):
             cw = None
         return cw
 
+    @staticmethod
+    def self_intersect(points):
+        """
+        Return true if the path defined by a list of points
+        intersects itself
+        """
+        from . import graph
+        polygon = _SingleSphericalPolygon(points)
+        g = graph.Graph((polygon,))
+        return g._find_all_intersections()
+
     def to_lonlat(self):
         """
         Convert the `SphericalPolygon` footprint to longitude and latitude


### PR DESCRIPTION
Two changes have been made to the library. The first is that SphericalPolygon has a new static method, self_intersect. It returns a boolean value that indicates if a list of points passed to it
intersects itself. Although SphericalPolygon handles self intersecting paths, it can be good to know if this is a problem ahead of time the calling sequence is:

    if SphericalPolygon.self_intersect(points):
       pass

The second change affects how Graph traces out paths at an intersection betweeen edges. When this happens there is on entering edge and three leaving edges and the tracing code needs to choose one of the three edges. The code computes the normal vector for each edge,
takes the dot product between the normal vector of the entering edge and each of the three leaving edges and chooses the one in the middle. The modification to the code computes the orientation of the leaving edges with respect to the entering edge. Some edges are "flipped" with respect to the entering edge. That is, the last point of the entering edge is equal to the last point of the edge instead of the first point. In this case the normal vector of the edge has the wrong sign and also needs to be "flipped" so that the dot product is computed correctly.