### PR TITLE
Remove unnecessary import

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -17,7 +17,6 @@ import numpy as np
 
 # LOCAL
 from . import great_circle_arc as gca
-from . import math_util
 from . import vector
 from . import polygon as mpolygon
 


### PR DESCRIPTION
math_util is not used but causes errors if the C extensions have not been built.