### PR TITLE
Revert change to pixel_shape

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Version 1.2.7 on 14 November 2018
+
+Restored _naxis, pixel_shape not ready yet≈ß
+
+
 ## Version 1.2.6 on 13 November 2018
 
 Replaced _naxis with pixel_shape

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.2.6'
+VERSION = '1.2.7'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -282,7 +282,7 @@ class SingleSphericalPolygon(object):
             wcs = pywcs.WCS(fitspath)
         if crval is not None:
             wcs.wcs.crval = crval
-        xa, ya = wcs.pixel_shape
+        xa, ya = (wcs._naxis1, wcs._naxis2)
 
         length = steps * 4 + 1
         X = np.empty(length)


### PR DESCRIPTION
Pixel_shape is not yet in general release, so the change has been reverted. I also bumped the version number and updated the change file, to make a final release befor I give up support of this package.