### PR TITLE
Astropy31 compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version 1.2.8 on 22 February 2019
+
+Add backwards compatibility with Astropy 3.1.0
+
+`<3.1.0` uses `wcs._naxis`
+`>=3.1.0` uses `wcs.pixel_shape`
+
+
 ## Version 1.2.7 on 14 November 2018
 
 Restored _naxis, pixel_shape not ready yet≈ß

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.2.7'
+VERSION = '1.2.8'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -282,7 +282,11 @@ class SingleSphericalPolygon(object):
             wcs = pywcs.WCS(fitspath)
         if crval is not None:
             wcs.wcs.crval = crval
-        xa, ya = (wcs._naxis1, wcs._naxis2)
+
+        if astropy.version.version_info < (3, 1, 0):
+            xa, ya = (wcs._naxis1, wcs._naxis2)
+        else:
+            xa, ya = wcs.pixel_shape
 
         length = steps * 4 + 1
         X = np.empty(length)


### PR DESCRIPTION
Make use of [now] deprecated `wcs._naxis` calls when Astropy `<3.1.0` is installed.