### PR TITLE
Fix incorrect query of astropy version information.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version 1.2.10 on 1 March 2019
+
+Fix incorrect query of astropy version information to deal with
+deprecation of ``_naxis1`` and ``_naxis2`` WCS attributes. [#165]
+
+
 ## Version 1.2.9 on 22 February 2019
 
 Fixed a bug introduced in version ``1.2.8``

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.2.9'
+VERSION = '1.2.10'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -283,10 +283,10 @@ class SingleSphericalPolygon(object):
         if crval is not None:
             wcs.wcs.crval = crval
 
-        if astropy_ver.version_info < (3, 1, 0):
-            xa, ya = (wcs._naxis1, wcs._naxis2)
-        else:
+        try:
             xa, ya = wcs.pixel_shape
+        except AttributeError:
+            xa, ya = (wcs._naxis1, wcs._naxis2)
 
         length = steps * 4 + 1
         X = np.empty(length)


### PR DESCRIPTION
This PR fixes how the code deals with deprecation of `WCS._naxis1` and `WCS._naxis2` without relying on `astropy.version`.