### PR TITLE
Fixes needed for intersect() code

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -637,8 +637,8 @@ class Graph:
         intersecting pair, four new edges are created around the
         intersection point.
         """
-        changed = self._find_point_to_arc_intersections()
-        changed = self._find_arc_to_arc_intersections() or changed
+        changed = self._find_arc_to_arc_intersections() 
+        changed = self._find_point_to_arc_intersections() or changed
         return changed
 
     def _remove_interior_edges(self):

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -444,7 +444,7 @@ class Graph:
 
         poly = self._trace()
         # If multiple polygons, the inside point can only be in one
-        if len(poly._polygons) ==1 not self._contains_inside_point(poly):
+        if len(poly._polygons)==1 and not self._contains_inside_point(poly):
             poly = poly.invert_polygon()
         return poly
 

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -443,7 +443,8 @@ class Graph:
         self._sanity_check("intersection - remove orphan nodes", True)
 
         poly = self._trace()
-        if not self._contains_inside_point(poly):
+        # If multiple polygons, the inside point can only be in one
+        if len(poly._polygons) ==1 not self._contains_inside_point(poly):
             poly = poly.invert_polygon()
         return poly
 

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -66,9 +66,11 @@ def _cross_and_normalize(A, B):
     # Normalization
     l = np.sqrt(np.sum(T ** 2, axis=-1))
     l = two_d(l)
-    # Might get some divide-by-zeros, but we don't care
+    # Might get some divide-by-zeros
     with np.errstate(invalid='ignore'):
         TN = T / l
+    # ... but set to zero, or we miss real NaNs elsewhere
+    TN = np.nan_to_num(TN)
     return TN
 
 


### PR DESCRIPTION
Hi.
Three small issues found when using the spherical_geometry library with intersect() method to find the intersection of a satellite orbit with a polygon.

(1) Need to zero entries when doing a div-by-zero.   In some cases, if the div-by-zero set to 0 is not done, you get incorrect NaNs which means intersections can be missed elsewhere, where !NaNs are counted.
(2) invert_polygon logic: a false assert. If two polygons are generated, the original interior point will only be in one, but you've two polygons, so you can't invert them.
(2) find_all_intersections() : swap the order of operations, or pathological cases lead to edges being accidentally removed in find_arc_to_arc_intersections(), leading to whole polygons being incorrectly removed in the intersection() method.