### PR TITLE
Fix intersection crash similar poly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version 1.2.11.dev Unreleased
+
+Increase the dimension of the confusion region in which two nodes are
+considered to be equal. This reduces the likelihood of crashes when
+computing intersections of nearly identical polygons. [#170]
+
 ## Version 1.2.10 on 1 March 2019
 
 Fix incorrect query of astropy version information to deal with

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -224,7 +224,7 @@ class Graph:
             The new node
         """
         # Any nodes whose Cartesian coordinates are closer together
-        # than 2 ** -32 will cause numerical problems in the
+        # than 2 ** -30 will cause numerical problems in the
         # intersection calculations, so we merge any nodes that
         # are closer together than that.
 
@@ -237,7 +237,7 @@ class Graph:
             nodes = list(self._nodes)
             node_array = np.array([node._point for node in nodes])
 
-            diff = np.all(np.abs(point - node_array) < 2 ** -32, axis=-1)
+            diff = np.all(np.abs(point - node_array) < 2 ** -29, axis=-1)
 
             indices = np.nonzero(diff)[0]
             if len(indices):
@@ -637,7 +637,7 @@ class Graph:
         intersecting pair, four new edges are created around the
         intersection point.
         """
-        changed = self._find_arc_to_arc_intersections() 
+        changed = self._find_arc_to_arc_intersections()
         changed = self._find_point_to_arc_intersections() or changed
         return changed
 

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -224,7 +224,7 @@ class Graph:
             The new node
         """
         # Any nodes whose Cartesian coordinates are closer together
-        # than 2 ** -30 will cause numerical problems in the
+        # than 2 ** -29 will cause numerical problems in the
         # intersection calculations, so we merge any nodes that
         # are closer together than that.
 

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -202,7 +202,7 @@ def test_self_intersection():
     s1 = polygon.SphericalPolygon.from_radec(np.array(ra1), np.array(dec1))
     s2 = polygon.SphericalPolygon.from_radec(np.array(ra2), np.array(dec2))
     s12 = s2.union(s1)
-    # asserts self-intersection is same as original 
+    # asserts self-intersection is same as original
     s12int = s12.intersection(s12)
     assert(abs(s12.area() - s12int.area()) < 1.0e-6)
     # same, with multi_intersection method
@@ -271,7 +271,7 @@ def test_ordering():
         BS = roll_polygon(B, i)
 
         C = AS.intersection(BS)
-        
+
         Aareas.append(A.area())
         Bareas.append(B.area())
         Careas.append(C.area())
@@ -354,3 +354,29 @@ def test_intersection_crash():
     poly = polygon.SphericalPolygon(polypoints, inside=polycenter)
 
     overlap = poly.overlap(testFoV)
+
+
+def test_intersection_crash_similar_poly():
+    p1 = polygon.SphericalPolygon(
+        np.array([[-0.1094946215827374, -0.8592766830993238, -0.499654390280199 ],
+                  [-0.1089683641318892, -0.8595220381654031, -0.4993473355555343],
+                  [-0.108610535224965 , -0.8593183788298407, -0.4997756250993051],
+                  [-0.1091500557209236, -0.8590667764452905, -0.5000905307482003],
+                  [-0.1094946215827374, -0.8592766830993238, -0.499654390280199 ]]),
+        np.array([-0.1090595793730483, -0.8592979843505629, -0.4997128998115153])
+    )
+
+    p2 = polygon.SphericalPolygon(
+        np.array([[-0.1094946213367254, -0.8592766831114167, -0.4996543903133135],
+                  [-0.1089683641834766, -0.859522038038747 , -0.4993473357622887],
+                  [-0.1086105354789061, -0.8593183788183577, -0.4997756250638628],
+                  [-0.109150055669766 , -0.8590667765760884, -0.5000905305346783],
+                  [-0.1094946213367254, -0.8592766831114167, -0.4996543903133135]]),
+        np.array([-0.1090595793730483, -0.8592979843505629, -0.4997128998115153])
+    )
+
+    p3 = p1.intersection(p2)
+
+    pts1 = np.sort(list(p1.points)[0][:-1], axis=0)
+    pts3 = np.sort(list(p3.points)[0][:-1], axis=0)
+    assert np.allclose(pts1, pts3, rtol=0, atol=1e-15)


### PR DESCRIPTION
This PR improves the reliability of computing intersections of almost identical polygons. This PR is closely related to https://github.com/spacetelescope/stsci.skypac/pull/49 Also an additional test is added to the unit tests.