### PR TITLE
Decrease confusion region for nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 Increase the dimension of the confusion region in which two nodes are
 considered to be equal. This reduces the likelihood of crashes when
-computing intersections of nearly identical polygons. [#170]
+computing intersections of nearly identical polygons. [#170, #173]
 
 ## Version 1.2.10 on 1 March 2019
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = .git build docs/_build
 

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -224,7 +224,7 @@ class Graph:
             The new node
         """
         # Any nodes whose Cartesian coordinates are closer together
-        # than 2 ** -29 will cause numerical problems in the
+        # than 2 ** -31 will cause numerical problems in the
         # intersection calculations, so we merge any nodes that
         # are closer together than that.
 
@@ -237,7 +237,7 @@ class Graph:
             nodes = list(self._nodes)
             node_array = np.array([node._point for node in nodes])
 
-            diff = np.all(np.abs(point - node_array) < 2 ** -29, axis=-1)
+            diff = np.all(np.abs(point - node_array) < 2 ** -31, axis=-1)
 
             indices = np.nonzero(diff)[0]
             if len(indices):

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -183,8 +183,7 @@ def test_from_wcs():
     from astropy.io import fits
 
     filename = os.path.join(ROOT_DIR, 'j8bt06nyq_flt.fits')
-    hdulist = fits.open(filename)
-    header = hdulist['SCI'].header
+    header = fits.getheader(filename, ext=('SCI', 1))
 
     poly = polygon.SphericalPolygon.from_wcs(header)
     for lonlat in poly.to_lonlat():
@@ -301,8 +300,8 @@ def test_point_in_poly():
 
 def test_point_in_poly_lots():
     from astropy.io import fits
-    fits = fits.open(resolve_imagename(ROOT_DIR, '1904-77_TAN.fits'))
-    header = fits[0].header
+    header = fits.getheader(resolve_imagename(ROOT_DIR, '1904-77_TAN.fits'),
+                            ext=0)
 
     poly1 = polygon.SphericalPolygon.from_wcs(
         header, 1, crval=[0, 87])

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -75,7 +75,7 @@ class intersection_test:
                 assert np.all(intersection_area * 0.9 <= areas)
 
             lengths = np.array([
-                np.sum(len(x._points) for x in y.iter_polygons_flat())
+                sum(len(x._points) for x in y.iter_polygons_flat())
                 for y in intersections])
             assert np.all(lengths == [lengths[0]])
             areas = np.array([x.area() for x in intersections])
@@ -88,8 +88,8 @@ class intersection_test:
 def test1():
     from astropy.io import fits
 
-    fits = fits.open(resolve_imagename(ROOT_DIR,'1904-66_TAN.fits'))
-    header = fits[0].header
+    filename = resolve_imagename(ROOT_DIR,'1904-66_TAN.fits')
+    header = fits.getheader(filename, ext=0)
 
     poly1 = polygon.SphericalPolygon.from_wcs(
         header, 1, crval=[0, 87])
@@ -110,8 +110,8 @@ def test2():
 @intersection_test(0, 90)
 def test3():
     from astropy.io import fits
-    fits = fits.open(resolve_imagename(ROOT_DIR, '1904-66_TAN.fits'))
-    header = fits[0].header
+    filename = resolve_imagename(ROOT_DIR,'1904-66_TAN.fits')
+    header = fits.getheader(filename, ext=0)
 
     poly1 = polygon.SphericalPolygon.from_wcs(
         header, 1, crval=[0, 87])
@@ -125,17 +125,17 @@ def test4():
     from astropy.io import fits
     from astropy import wcs as pywcs
 
-    A = fits.open(os.path.join(ROOT_DIR, '2chipA.fits.gz'))
-    B = fits.open(os.path.join(ROOT_DIR, '2chipB.fits.gz'))
+    with fits.open(os.path.join(ROOT_DIR, '2chipA.fits.gz')) as A:
+        wcs = pywcs.WCS(A[1].header, fobj=A)
+        chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
+        wcs = pywcs.WCS(A[4].header, fobj=A)
+        chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
 
-    wcs = pywcs.WCS(A[1].header, fobj=A)
-    chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(A[4].header, fobj=A)
-    chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(B[1].header, fobj=B)
-    chipB1 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(B[4].header, fobj=B)
-    chipB2 = polygon.SphericalPolygon.from_wcs(wcs)
+    with fits.open(os.path.join(ROOT_DIR, '2chipB.fits.gz')) as B:
+        wcs = pywcs.WCS(B[1].header, fobj=B)
+        chipB1 = polygon.SphericalPolygon.from_wcs(wcs)
+        wcs = pywcs.WCS(B[4].header, fobj=B)
+        chipB2 = polygon.SphericalPolygon.from_wcs(wcs)
 
     Apoly = chipA1.union(chipA2)
     Bpoly = chipB1.union(chipB2)
@@ -146,8 +146,8 @@ def test4():
 @intersection_test(0, 90)
 def test6():
     from astropy.io import fits
-    fits = fits.open(resolve_imagename(ROOT_DIR, '1904-66_TAN.fits'))
-    header = fits[0].header
+    filename = resolve_imagename(ROOT_DIR,'1904-66_TAN.fits')
+    header = fits.getheader(filename, ext=0)
 
     poly1 = polygon.SphericalPolygon.from_wcs(
         header, 1)
@@ -173,9 +173,9 @@ def test_difficult_intersections():
     # Tests a number of intersections of real data that have been
     # problematic in previous revisions of spherical_geometry
 
-    def test_intersection(polys):
-        A, B = polys
-        A.intersection(B)
+    # def test_intersection(polys):
+        # A, B = polys
+        # A.intersection(B)
 
     fname = resolve_imagename(ROOT_DIR, "difficult_intersections.txt")
     with open(fname, 'rb') as fd:
@@ -190,7 +190,8 @@ def test_difficult_intersections():
             to_array(line) for line in lines[i:i+4]]
         polyA = polygon.SphericalPolygon(Apoints, Ainside)
         polyB = polygon.SphericalPolygon(Bpoints, Binside)
-        yield test_intersection, (polyA, polyB)
+        # yield test_intersection, (polyA, polyB)
+        polyA.intersection(polyB)
 
 def test_self_intersection():
     # Tests intersection between a disjoint polygon and itself

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -75,7 +75,7 @@ class union_test:
                 assert np.all(union_area * 1.1 >= areas)
 
             lengths = np.array([
-                np.sum(len(x._points) for x in y.iter_polygons_flat())
+                sum(len(x._points) for x in y.iter_polygons_flat())
                 for y in unions])
             assert np.all(lengths == [lengths[0]])
             areas = np.array([x.area() for x in unions])
@@ -87,8 +87,8 @@ class union_test:
 @union_test(0, 90)
 def test1():
     from astropy.io import fits
-    fits = fits.open(resolve_imagename(ROOT_DIR, '1904-77_TAN.fits'))
-    header = fits[0].header
+    filename = resolve_imagename(ROOT_DIR,'1904-66_TAN.fits')
+    header = fits.getheader(filename, ext=0)
 
     poly1 = polygon.SphericalPolygon.from_wcs(
         header, 1, crval=[0, 87])
@@ -117,12 +117,11 @@ def test5():
     from astropy.io import fits
     from astropy import wcs as pywcs
 
-    A = fits.open(os.path.join(ROOT_DIR, '2chipA.fits.gz'))
-
-    wcs = pywcs.WCS(A[1].header, fobj=A)
-    chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(A[4].header, fobj=A)
-    chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
+    with fits.open(os.path.join(ROOT_DIR, '2chipA.fits.gz')) as A:
+        wcs = pywcs.WCS(A[1].header, fobj=A)
+        chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
+        wcs = pywcs.WCS(A[4].header, fobj=A)
+        chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
 
     null_union = chipA1.union(chipA2)
 
@@ -131,12 +130,11 @@ def test6():
     from astropy.io import fits
     from astropy import wcs as pywcs
 
-    A = fits.open(os.path.join(ROOT_DIR, '2chipC.fits.gz'))
-
-    wcs = pywcs.WCS(A[1].header, fobj=A)
-    chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(A[4].header, fobj=A)
-    chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
+    with fits.open(os.path.join(ROOT_DIR, '2chipC.fits.gz')) as A:
+        wcs = pywcs.WCS(A[1].header, fobj=A)
+        chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
+        wcs = pywcs.WCS(A[4].header, fobj=A)
+        chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
 
     null_union = chipA1.union(chipA2)
 
@@ -146,19 +144,17 @@ def test7():
     from astropy.io import fits
     from astropy import wcs as pywcs
 
-    A = fits.open(os.path.join(ROOT_DIR, '2chipA.fits.gz'))
+    with fits.open(os.path.join(ROOT_DIR, '2chipA.fits.gz')) as A:
+        wcs = pywcs.WCS(A[1].header, fobj=A)
+        chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
+        wcs = pywcs.WCS(A[4].header, fobj=A)
+        chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
 
-    wcs = pywcs.WCS(A[1].header, fobj=A)
-    chipA1 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(A[4].header, fobj=A)
-    chipA2 = polygon.SphericalPolygon.from_wcs(wcs)
-
-    B = fits.open(os.path.join(ROOT_DIR, '2chipB.fits.gz'))
-
-    wcs = pywcs.WCS(B[1].header, fobj=B)
-    chipB1 = polygon.SphericalPolygon.from_wcs(wcs)
-    wcs = pywcs.WCS(B[4].header, fobj=B)
-    chipB2 = polygon.SphericalPolygon.from_wcs(wcs)
+    with fits.open(os.path.join(ROOT_DIR, '2chipB.fits.gz')) as B:
+        wcs = pywcs.WCS(B[1].header, fobj=B)
+        chipB1 = polygon.SphericalPolygon.from_wcs(wcs)
+        wcs = pywcs.WCS(B[4].header, fobj=B)
+        chipB2 = polygon.SphericalPolygon.from_wcs(wcs)
 
     return [chipA1, chipA2, chipB1, chipB2]
 
@@ -167,8 +163,8 @@ def test7():
 def test8():
     from astropy.io import fits
 
-    fits = fits.open(resolve_imagename(ROOT_DIR, '1904-66_TAN.fits'))
-    header = fits[0].header
+    filename = resolve_imagename(ROOT_DIR,'1904-66_TAN.fits')
+    header = fits.getheader(filename, ext=0)
 
     poly1 = polygon.SphericalPolygon.from_wcs(
         header, 1)


### PR DESCRIPTION
This PR decreases the uncertainty region in which two nodes are considered the same partially undoing changes in #170. This is because for unknown yet reasons, #170 caused failures in unit tests in `tweakwcs`. Also, cleaned up unit tests (a little).