### PR TITLE
Restore old tolerance for node closeness  detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,19 @@
-## Version 1.2.11.dev Unreleased
+## Version 1.2.13 on 30 July 2019
+
+Undo-ing changes from release 1.2.11 (PRs #170 and #173) due to crashes in the
+union of multi-polygons until a better solution is found. [#176]
+
+## Version 1.2.12
+
+Package structure was updated.
+
+
+## Version 1.2.11
 
 Increase the dimension of the confusion region in which two nodes are
 considered to be equal. This reduces the likelihood of crashes when
 computing intersections of nearly identical polygons. [#170, #173]
+
 
 ## Version 1.2.10 on 1 March 2019
 

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -224,7 +224,7 @@ class Graph:
             The new node
         """
         # Any nodes whose Cartesian coordinates are closer together
-        # than 2 ** -31 will cause numerical problems in the
+        # than 2 ** -32 will cause numerical problems in the
         # intersection calculations, so we merge any nodes that
         # are closer together than that.
 
@@ -237,7 +237,7 @@ class Graph:
             nodes = list(self._nodes)
             node_array = np.array([node._point for node in nodes])
 
-            diff = np.all(np.abs(point - node_array) < 2 ** -31, axis=-1)
+            diff = np.all(np.abs(point - node_array) < 2 ** -32, axis=-1)
 
             indices = np.nonzero(diff)[0]
             if len(indices):

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -8,6 +8,7 @@ import math
 import os
 import random
 import sys
+import pytest
 
 # THIRD-PARTY
 from astropy.extern.six.moves import xrange
@@ -356,7 +357,7 @@ def test_intersection_crash():
 
     overlap = poly.overlap(testFoV)
 
-
+@pytest.mark.skip(reason="currently there is no solution to get this to pass")
 def test_intersection_crash_similar_poly():
     p1 = polygon.SphericalPolygon(
         np.array([[-0.1094946215827374, -0.8592766830993238, -0.499654390280199 ],


### PR DESCRIPTION
Undo changes from #170 and #173 because those changes, while reducing the crashes in the intersection computations, have resulted in crashes during union computations. This PR undoes previous solution until the issue is understood completely and there is a reliable solution. 

CC: @jhunkeler 