### PR TITLE
Use relative path for sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Version 1.2.17 on 15 August 2019
+
+- Fixed unexpected behavior if using pip on Windows
+
+
 ## Version 1.2.16 on 13 August 2019
 
 - Updated qd library to 2.3.22

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ have_windows = bool(sys.platform.startswith('win'))
 have_darwin = bool(sys.platform == 'Darwin')
 have_linux = bool(sys.platform == 'linux')
 
-qd_library_path = os.path.abspath(os.path.join('libqd'))
+qd_library_path = os.path.relpath(os.path.join('libqd'))
 qd_library_c_path = os.path.join(qd_library_path, 'src')
 qd_library_include_path = os.path.join(qd_library_path, 'include')
 qd_sources = glob(os.path.join(qd_library_c_path, '*.cpp'))


### PR DESCRIPTION
* Avoids .egg-info from assimilating local system paths

@stsci-hack reported the following failure occurring in `drizzlepac`'s build:
https://dev.azure.com/spacetelescope/drizzlepac/_build/results?buildId=1257&view=logs&jobId=094df02d-42f3-5942-83e9-798405c0fd82&taskId=15c70358-89e9-5290-5e64-20274e23afb5&lineStart=346&lineEnd=350&colStart=1&colEnd=54

```python
    File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\distutils\util.py", line 125, in convert_path
      raise ValueError("path '%s' cannot be absolute" % pathname)
  ValueError: path '/Users/jhunk/Downloads/spherical_geometry/libqd/src/bits.cpp' cannot be absolute
  ----------------------------------------
  ERROR: Failed building wheel for spherical-geometry
```

Turns out paths in the `sources` list passed to the `Extension` builder are stored verbatim by `sdist`.