### PR TITLE
Replace xrange calls with range since python2 is no longer supported.

### DIFF
--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -11,7 +11,6 @@ import sys
 import pytest
 
 # THIRD-PARTY
-from astropy.extern.six.moves import xrange
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
@@ -249,7 +248,7 @@ def test_ordering():
         [3.532883212044564125e-01, 6.354215160430938258e-01, -6.866053153377369433e-01])
 
     areas = []
-    for i in xrange(nrepeat):
+    for i in range(nrepeat):
         C = A.intersection(B)
         areas.append(C.area())
     areas = np.array(areas)
@@ -268,7 +267,7 @@ def test_ordering():
     Aareas = []
     Bareas = []
     Careas = []
-    for i in xrange(nrepeat):
+    for i in range(nrepeat):
         AS = roll_polygon(A, i)
         BS = roll_polygon(B, i)
 
@@ -278,7 +277,7 @@ def test_ordering():
         Bareas.append(B.area())
         Careas.append(C.area())
 
-        for j in xrange(nrepeat):
+        for j in range(nrepeat):
             CS = roll_polygon(C, j)
             Careas.append(CS.area())
 


### PR DESCRIPTION
Remove xrange import from astropy.extern