### PR TITLE
Build against oldest Astropy supported version of Numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>=38.2.5", "setuptools_scm", "wheel", "numpy"]
+requires = ["setuptools>=38.2.5", "setuptools_scm", "wheel", "oldest-supported-numpy"]


### PR DESCRIPTION
Declare a pyproject.toml build dependency on `oldest-supported-numpy` so that wheels work with the widest possible range of Numpy versions.