### PR TITLE
MNT: Update codecov-action version to v2

### DIFF
--- a/.github/workflows/spherical_geometry.yml
+++ b/.github/workflows/spherical_geometry.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         pytest --cov-report=xml --cov=. --cov-config=setup.cfg
     - name: Upload coverage to codecoverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
 


### PR DESCRIPTION
You are using a deprecated version of `codecov-action`, see https://github.com/codecov/codecov-action for more details. xref astropy/astropy#12245

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.