### PR TITLE
MNT: Stop using astropy raises and distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,11 @@
 
 import os
 import sys
-
+import shutil
 from glob import glob
 from setuptools import setup
 from setuptools import Extension
 from setuptools import find_packages
-from distutils.spawn import find_executable
 
 use_system_qd = os.environ.get('USE_SYSTEM_QD', '')
 have_windows = bool(sys.platform.startswith('win'))
@@ -19,6 +18,7 @@ qd_library_path = os.path.relpath(os.path.join('libqd'))
 qd_library_c_path = os.path.join(qd_library_path, 'src')
 qd_library_include_path = os.path.join(qd_library_path, 'include')
 qd_sources = glob(os.path.join(qd_library_c_path, '*.cpp'))
+
 
 def qd_config(arg):
     result = ''
@@ -51,7 +51,7 @@ def qd_config(arg):
                 exit(1)
         else:
             from subprocess import check_output
-            if not find_executable('qd-config'):
+            if not shutil.which('qd-config'):
                 print('"qd-config" not found. Please install "qd" '
                       '(see: https://www.davidhbailey.com/dhbsoftware)',
                       file=sys.stderr)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -5,10 +5,9 @@ import os.path
 import math
 import random
 
-from astropy.tests.helper import raises
-
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_less
+import pytest
+from numpy.testing import assert_almost_equal
 
 from .. import graph
 from .. import great_circle_arc
@@ -505,12 +504,12 @@ def test_convex_hull():
         assert b == r, "Polygon boundary has correct points"
 
 
-@raises(ValueError)
 def test_math_util_angle_domain():
     # Before a fix, this would segfault
-    math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])
+    with pytest.raises(ValueError):
+        math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])
 
 
-@raises(ValueError)
 def test_math_util_length_domain():
-    math_util.length([[np.nan, 0, 0]], [[0, 0, np.inf]])
+    with pytest.raises(ValueError):
+        math_util.length([[np.nan, 0, 0]], [[0, 0, np.inf]])


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .

Also remove the use of deprecated `distutils`.