### PR TITLE
Prepare 1.2.21 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,14 @@
 Release Notes
 =============
 
-.. 1.2.21 (unreleased)
+.. 1.2.22 (unreleased)
    ===================
+
+
+1.2.21 (30-December-2021)
+=========================
+
+Maintenance release.
 
 
 1.2.20 (12-May-2021)


### PR DESCRIPTION
This is to update changelog for the next release. The 1.2.21 release is a maintenance release.