### PR TITLE
Fix segfault with numpy 1.22

### DIFF
--- a/.github/workflows/spherical_geometry.yml
+++ b/.github/workflows/spherical_geometry.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install numpy
         python -m pip install -e .[test]
     - name: Test with pytest
       run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@ Release Notes
    ===================
 
 
+1.2.22 (unreleased)
+===================
+
+- Fixed segmentation fault occuring in the ``math_util`` module when
+  ``spherical_geometry`` is used with ``numpy`` version ``1.22`` due to
+  incorrect ``ntypes`` value being used when defining generalized
+  universal functions. [#216]
+
+
 1.2.21 (30-December-2021)
 =========================
 

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -743,7 +743,7 @@ addUfuncs(PyObject *dictionary) {
     PyObject *f;
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        inner1d_functions, inner1d_data, inner1d_signatures, 2, 2, 1,
+        inner1d_functions, inner1d_data, inner1d_signatures, 1, 2, 1,
         PyUFunc_None, "inner1d",
         "inner on the last dimension and broadcast on the rest \n"      \
         "     \"(i),(i)->()\" \n",
@@ -752,7 +752,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        normalize_functions, normalize_data, normalize_signatures, 2, 1, 1,
+        normalize_functions, normalize_data, normalize_signatures, 1, 1, 1,
         PyUFunc_None, "normalize",
         "Normalize the vector to the unit sphere. \n"      \
         "     \"(i)->(i)\" \n",
@@ -761,7 +761,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        cross_functions, cross_data, cross_signatures, 2, 2, 1,
+        cross_functions, cross_data, cross_signatures, 1, 2, 1,
         PyUFunc_None, "cross",
         "cross product of 3-vectors only \n" \
         "     \"(i),(i)->(i)\" \n",
@@ -770,7 +770,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        cross_and_norm_functions, cross_and_norm_data, cross_and_norm_signatures, 2, 2, 1,
+        cross_and_norm_functions, cross_and_norm_data, cross_and_norm_signatures, 1, 2, 1,
         PyUFunc_None, "cross_and_norm",
         "cross_and_norm product of 3-vectors only \n" \
         "     \"(i),(i)->(i)\" \n",
@@ -779,7 +779,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        triple_product_functions, triple_product_data, triple_product_signatures, 2, 3, 1,
+        triple_product_functions, triple_product_data, triple_product_signatures, 1, 3, 1,
         PyUFunc_None, "triple_product",
         "Calculate the triple_product between A, B and C.\n" \
         "     \"(i),(i),(i)->()\" \n",
@@ -789,7 +789,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        intersection_functions, intersection_data, intersection_signatures, 2, 4, 1,
+        intersection_functions, intersection_data, intersection_signatures, 1, 4, 1,
         PyUFunc_None, "intersection",
         "intersection product of 3-vectors only \n" \
         "     \"(i),(i),(i),(i)->(i)\" \n",
@@ -798,7 +798,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        intersects_functions, intersects_data, intersects_signatures, 2, 4, 1,
+        intersects_functions, intersects_data, intersects_signatures, 1, 4, 1,
         PyUFunc_None, "intersects",
         "true where AB intersects CD \n" \
         "     \"(i),(i),(i),(i)->()\" \n",
@@ -807,7 +807,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        length_functions, length_data, length_signatures, 2, 2, 1,
+        length_functions, length_data, length_signatures, 1, 2, 1,
         PyUFunc_None, "length",
         "length of great circle arc \n" \
         "     \"(i),(i)->()\" \n",
@@ -816,7 +816,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        intersects_point_functions, intersects_point_data, intersects_point_signatures, 2, 3, 1,
+        intersects_point_functions, intersects_point_data, intersects_point_signatures, 1, 3, 1,
         PyUFunc_None, "intersects_point",
         "True where point C intersects arc AB \n" \
         "     \"(i),(i),(i)->()\" \n",
@@ -825,7 +825,7 @@ addUfuncs(PyObject *dictionary) {
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
-        angle_functions, angle_data, angle_signatures, 2, 3, 1,
+        angle_functions, angle_data, angle_signatures, 1, 3, 1,
         PyUFunc_None, "angle",
         "Calculate the angle at B between AB and BC.\n" \
         "     \"(i),(i),(i)->()\" \n",


### PR DESCRIPTION
It has been reported, see, i.e., https://github.com/spacetelescope/jwst/issues/6539, that `spherical_geometry` was causing a segmentation fault on import when used with `numpy==1.22`.

This PR fixes this issue which was caused by incorrect number of `ntypes` (2) being passed to the `PyUFunc_FromFuncAndDataAndSignature` function when only one (1) type is actually supported.

Fixes https://github.com/spacetelescope/jwst/issues/6539