### PR TITLE
fix problem with C version of angle function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Release Notes
 
 - Set Python min version to 3.8. [#219]
 
-- Fix problem problem reported where angle of 180 degrees results in an
+- Fix problem reported where angle of 180 degrees results in an
   error with the C version of the code. [#223]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Release Notes
 - Set Python min version to 3.8. [#219]
 
 - Fix problem problem reported where angle of 180 degrees results in an
-  error with the C version of the code.
+  error with the C version of the code. [#223]
 
 
 1.2.22 (04-January-2022)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Release Notes
 
 - Set Python min version to 3.8. [#219]
 
+- Fix problem problem reported where angle of 180 degrees results in an
+  error with the C version of the code.
+
 
 1.2.22 (04-January-2022)
 ========================

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -327,10 +327,8 @@ def angle(A, B, C, degrees=True):
 
         A, B, C = np.broadcast_arrays(A, B, C)
 
-        ABX = _fast_cross(A, B)
-        ABX = _cross_and_normalize(B, ABX)
-        BCX = _fast_cross(C, B)
-        BCX = _cross_and_normalize(B, BCX)
+        ABX = _cross_and_normalize(A, B)
+        BCX = _cross_and_normalize(C, B)
         X = _cross_and_normalize(ABX, BCX)
         diff = inner1d(B, X)
         inner = inner1d(ABX, BCX)

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -160,7 +160,6 @@ dot_qd(const qd *A, const qd *B, qd *C) {
 
     for (i = 0; i < 3; ++i) {
         c_qd_mul(A[i].x, B[i].x, tmp[i]);
-        // c_qd_mul(A[i], B[i], tmp[i]);
     }
 
     c_qd_add(tmp[0], tmp[1], tmp[3]);

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -160,6 +160,7 @@ dot_qd(const qd *A, const qd *B, qd *C) {
 
     for (i = 0; i < 3; ++i) {
         c_qd_mul(A[i].x, B[i].x, tmp[i]);
+        // c_qd_mul(A[i], B[i], tmp[i]);
     }
 
     c_qd_add(tmp[0], tmp[1], tmp[3]);
@@ -691,13 +692,11 @@ DOUBLE_angle(char **args, intp *dimensions, intp *steps, void *NPY_UNUSED(func))
         load_point_qd(ip2, is2, B);
         load_point_qd(ip3, is3, C);
 
-        cross_qd(A, B, TMP);
-        cross_qd(B, TMP, ABX);
+        cross_qd(A, B, ABX);
 
         if (normalize_qd(ABX, ABX)) return;
 
-        cross_qd(C, B, TMP);
-        cross_qd(B, TMP, BCX);
+        cross_qd(C, B, BCX);
 
         if (normalize_qd(BCX, BCX)) return;
 
@@ -708,6 +707,11 @@ DOUBLE_angle(char **args, intp *dimensions, intp *steps, void *NPY_UNUSED(func))
         dot_qd(B, X, &diff);
         dot_qd(ABX, BCX, &inner);
 
+        if (fabs(inner.x[0]) == 1.0 & fabs(inner.x[1]) < 1e-60) {
+            inner.x[1] = 0.;
+            inner.x[2] = 0.;
+            inner.x[3] = 0.;
+        }
         if (inner.x[0] != inner.x[0] ||
             inner.x[0] < -1.0 ||
             inner.x[0] > 1.0) {

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -706,7 +706,13 @@ DOUBLE_angle(char **args, intp *dimensions, intp *steps, void *NPY_UNUSED(func))
         dot_qd(B, X, &diff);
         dot_qd(ABX, BCX, &inner);
 
-        if (fabs(inner.x[0]) == 1.0 & fabs(inner.x[1]) < 1e-60) {
+        /* The following threshold is currently arbitrary and
+        is based on observed errors in that value and several 
+        orders of magnitude larger than those. One day someone
+        should determine how qd is producing those errors, 
+        but for now...
+        */
+        if (fabs(inner.x[0]) == 1.0 && fabs(inner.x[1]) < 1e-60) {
             inner.x[1] = 0.;
             inner.x[2] = 0.;
             inner.x[3] = 0.;


### PR DESCRIPTION
This fixes a problem reported in #222 where the C version of the angle UFunc erratically returns a NaN for coplanar vectors where the angle between the surface points should be 180 degrees. The problem actually appears to lie within the qd external package (now "vendorized" since it is no longer supported). The fix simply assigns 0 values to the higher precision components of the returned value for the `c_dq_dot` product. (The erratic values appear in the 2nd of the 4 double float values used to represent the result, the 3rd and 4th values are identically 0.0). No test has been added since it is an erratic error depending on the number of digits of one of the input values that should have no effect.

One further simplification was made to both the Python and C versions of the angle code, namely removing two unnecessary cross products (the previous code computed the sphere tangent vectors; dot products of those are identically the same as the dot product of the normalized cross products; i.e., the angle between the defined planes is exactly the same as the angle between the tangent vectors).