### PR TITLE
Add documenation as to SphericalPolygon multi_union method exponential time behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Release Notes
 
 - Add documentation to ``polygon.py`` for the ``SphericalPolygon`` 
   method ``multi_union`` has exponential time behavior and cannot
-  be used for a large number of polynomials []
+  be used for a large number of polynomials [#229]
 
 1.2.23 (10-October-2022)
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Release Notes
 1.2.24 (unreleased)
 ===================
 
+- Add documentation to ``polygon.py`` for the ``SphericalPolygon`` 
+  method ``multi_union`` has exponential time behavior and cannot
+  be used for a large number of polynomials []
+
 1.2.23 (10-October-2022)
 ========================
 

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -1145,7 +1145,9 @@ class SphericalPolygon(SingleSphericalPolygon):
     def multi_union(cls, polygons):
         """
         Return a new `SphericalPolygon` that is the union of all of the
-        polygons in *polygons*.
+        polygons in *polygons*. Currently this implementation exhibits
+        exponential time behavior and becomes practically unusable when 
+        dealing with on the order of 40 or more polygons.
 
         Parameters
         ----------


### PR DESCRIPTION
The current implementation has exponential time behavior that makes it impractical to use when roughly 40 or more polygons are used. Addresses #228.