### PR TITLE
Add Python 3.11 to CI test matrix

### DIFF
--- a/.github/workflows/spherical_geometry.yml
+++ b/.github/workflows/spherical_geometry.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Python 3.11 to the CI test matrix in order to resolve #225. The tests pass when run in a container using the `python:3.11` image.

Closes #225