### PR TITLE
TST: Turn skip to xfail

### DIFF
--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -344,7 +344,7 @@ def test_intersection_crash():
     _ = poly.overlap(testFoV)
 
 
-@pytest.mark.skip(reason="currently there is no solution to get this to pass")
+@pytest.mark.xfail(reason="currently there is no solution to get this to pass")
 def test_intersection_crash_similar_poly():
     p1 = polygon.SphericalPolygon(
         np.array([[-0.1094946215827374, -0.8592766830993238, -0.499654390280199 ],


### PR DESCRIPTION
We have `xfail_strict` on now, so you will know if it magically passes again if we mark it xfail instead of a blind skip.