### PR TITLE
Replace numpy's inner1d with an alternative implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Release Notes
 
 - Wheels for several common architectures are now available on PyPI. [#243]
 
+- Replaced private ``numpy.core._umath_tests.inner1d()`` with an alternative
+  implementation. [#253]
+
 1.2.23 (10-October-2022)
 ========================
 

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -29,7 +29,7 @@ __all__ = ['angle', 'intersection', 'intersects', 'intersects_point',
 if HAS_C_UFUNCS:
     inner1d = math_util.inner1d
 else:
-    from numpy.core._umath_tests import inner1d
+    inner1d = lambda x, y: np.multiply(x, y).sum(axis=1)
 
 
 if HAS_C_UFUNCS:

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -26,11 +26,15 @@ except ImportError:
 __all__ = ['angle', 'intersection', 'intersects', 'intersects_point',
            'length', 'midpoint', 'interpolate']
 
+
+def _inner1d_np(x, y):
+    return np.multiply(x, y).sum(axis=1)
+
+
 if HAS_C_UFUNCS:
     inner1d = math_util.inner1d
 else:
-    def inner1d(x, y):
-        return np.multiply(x, y).sum(axis=1)
+    inner1d = _inner1d_np
 
 
 if HAS_C_UFUNCS:
@@ -56,6 +60,7 @@ else:
 
         return cp
 
+
 if HAS_C_UFUNCS:
     def _cross_and_normalize(A, B):
         with np.errstate(invalid='ignore'):
@@ -72,6 +77,7 @@ else:
         # ... but set to zero, or we miss real NaNs elsewhere
         TN = np.nan_to_num(TN)
         return TN
+
 
 if HAS_C_UFUNCS:
     triple_product = math_util.triple_product

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -29,7 +29,8 @@ __all__ = ['angle', 'intersection', 'intersects', 'intersects_point',
 if HAS_C_UFUNCS:
     inner1d = math_util.inner1d
 else:
-    inner1d = lambda x, y: np.multiply(x, y).sum(axis=1)
+    def inner1d(x, y):
+        return np.multiply(x, y).sum(axis=1)
 
 
 if HAS_C_UFUNCS:

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -8,7 +8,11 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_allclose
 
 from spherical_geometry import graph, great_circle_arc, polygon, vector
-from spherical_geometry.tests.helpers import ROOT_DIR, get_point_set, resolve_imagename
+from spherical_geometry.tests.helpers import (
+    ROOT_DIR,
+    get_point_set,
+    resolve_imagename
+)
 
 try:
     from spherical_geometry import math_util
@@ -536,3 +540,35 @@ def test_math_util_angle_nearly_coplanar_vec():
 
     assert_allclose(angles[:-1], np.pi, rtol=0, atol=1e-16)
     assert_allclose(angles[-1], 0, rtol=0, atol=1e-32)
+
+
+def test_inner1d():
+    vectors = [
+        [1.0, 1.0, 1.0],
+        3 * [1.0 / np.sqrt(3)],
+        [1, 0.5, 1],
+        [1, 0.15, 1],
+        [-1, 0.1, -1]
+    ]
+    lengths = great_circle_arc._inner1d_np(vectors, vectors)
+
+    assert_allclose(lengths, [3.0, 1.0, 2.25, 2.0225, 2.01], rtol=0, atol=1e-15)
+
+
+@pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
+def test_math_util_inner1d():
+    vectors = [
+        [1.0, 1.0, 1.0],
+        3 * [1.0 / np.sqrt(3)],
+        [1, 0.5, 1],
+        [1, 0.15, 1],
+        [-1, 0.1, -1]
+    ]
+    lengths = great_circle_arc._inner1d_np(vectors, vectors)
+
+    assert_allclose(
+        lengths,
+        math_util.inner1d(vectors, vectors),
+        rtol=0,
+        atol=1e-15
+    )

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -564,11 +564,6 @@ def test_math_util_inner1d():
         [1, 0.15, 1],
         [-1, 0.1, -1]
     ]
-    lengths = great_circle_arc._inner1d_np(vectors, vectors)
+    lengths = math_util.inner1d(vectors, vectors)
 
-    assert_allclose(
-        lengths,
-        math_util.inner1d(vectors, vectors),
-        rtol=0,
-        atol=1e-15
-    )
+    assert_allclose(lengths, [3.0, 1.0, 2.25, 2.0225, 2.01], rtol=0, atol=1e-15)


### PR DESCRIPTION
This PR replaces the deprecated `numpy.core._umath_tests.inner1d()` (which will likely error in numpy>=2) with an alternative implementation.