### PR TITLE
Fix crash in convex_hull when input includes repeated points

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ Release Notes
 - Replaced private ``numpy.core._umath_tests.inner1d()`` with an alternative
   implementation. [#253]
 
+- Fixed a bug in the ``math_util.angles()`` function that would result in crash
+  when one of the input vectors is a null vector. [#254]
+
+- Enhanced the code in the ``SphericalPolygon.convex_hull()`` to ignore points
+  that lead to null vectors in computations. [#254]
+
 1.2.23 (10-October-2022)
 ========================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Release Notes
 - Enhanced the code in the ``SphericalPolygon.convex_hull()`` to ignore points
   that lead to null vectors in computations. [#254]
 
+
 1.2.23 (10-October-2022)
 ========================
 

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -348,7 +348,7 @@ class SingleSphericalPolygon(object):
 
         duo = list(zip(pt, ang))
         duo = sorted(duo, key=lambda d: d[1])
-        points = np.asarray([d[0] for d in duo])
+        points = np.asarray([d[0] for d in duo if np.isfinite(d[1])])
 
         # Set the first point on the hull to the extreme point
 

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -477,11 +477,18 @@ def test_fast_area():
     assert carea > 2.0 * np.pi and carea < 4.0 * np.pi
 
 
-def test_convex_hull():
+@pytest.mark.parametrize(
+    'repeat_pts', [False, True]
+)
+def test_convex_hull(repeat_pts):
     lon = (0.02, 0.10, 0.05, 0.03, 0.04, 0.07, 0.00, 0.06, 0.08, 0.13,
            0.08, 0.14, 0.15, 0.12, 0.01, 0.11)
     lat = (0.06, 0.00, 0.05, 0.01, 0.12, 0.08, 0.03, 0.02, 0.04, 0.03,
            0.10, 0.11, 0.01, 0.13, 0.09, 0.07)
+
+    if repeat_pts:
+        lon = lon + lon[::-1]
+        lat = lat + lat[::-1]
 
     lon_lat = list(zip(lon, lat))
 
@@ -518,8 +525,9 @@ def test_convex_hull():
 @pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
 def test_math_util_angle_domain():
     # Before a fix, this would segfault
-    with pytest.raises(ValueError):
-        math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])
+    assert not np.isfinite(
+        math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])[0]
+    )
 
 
 @pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")


### PR DESCRIPTION
Fixes #231 

This PR fixes a bug in the quad-accuracy `angle()` function that would result in a crash in convex_hull() when input includes repeated points.