### PR TITLE
Fix a bug in quad-precision functions normalize and intersection functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ Release Notes
 - Enhanced the code in the ``SphericalPolygon.convex_hull()`` to ignore points
   that lead to null vectors in computations. [#254]
 
+- Fixed a bug in quad-precision functions ``normalize`` and
+  ``intersection`` functions affecting numerous other functions. [#256]
+
 
 1.2.23 (10-October-2022)
 ========================

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -524,7 +524,6 @@ def test_convex_hull(repeat_pts):
 
 @pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
 def test_math_util_angle_domain():
-    # Before a fix, this would segfault
     assert not np.isfinite(
         math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])[0]
     )

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -149,6 +149,11 @@ normalize_qd(const qd *A, qd *B) {
         PyErr_SetString(PyExc_ValueError, "Domain error in sqrt");
         return 1;
     }
+    if (T[3][0] == 0.0) {
+        c_qd_copy_d(NPY_NAN, B->x);
+        return 1;
+    }
+
     c_qd_sqrt(T[3], l);
 
     for (i = 0; i < 3; ++i) {
@@ -267,7 +272,10 @@ intersection_qd(const qd *A, const qd *B, const qd *C, const qd *D,
         cross_qd(A, B, ABX);
         cross_qd(C, D, CDX);
         cross_qd(ABX, CDX, T);
-        if (normalize_qd(T, T)) return;
+        if (normalize_qd(T, T)) {
+            *match = 0;
+            return;
+        }
 
         *match = 0;
         cross_qd(ABX, A, tmp);


### PR DESCRIPTION
Fixes #186

This PR fixes a bug in quad-precision functions ``normalize`` and ``intersection`` functions affecting numerous other functions, such as ``contains_point()``.