### PR TITLE
Fix bugs in the Python implementation of inner1d and length

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,13 @@ Release Notes
 1.3.2 (unreleased)
 ==================
 
-- Fixed a bug in the Python implementation of ``inner1d``. [#266]
+- Fixed a bug in the Python implementation of ``inner1d``. [#265]
+
+- Removed the ``degree`` argument from the ``length`` and ``angle`` functions
+  in the ``spherical_geometry.great_circle_arc`` module as it was never working
+  correctly with the ``math_util`` module and add unnecessary
+  complication. [#265]
+
 
 1.3.1 (5-November-2023)
 =======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 Release Notes
 =============
 
+1.3.2 (unreleased)
+==================
+
+- Fixed a bug in the Python implementation of ``inner1d``. [#266]
+
 1.3.1 (5-November-2023)
 =======================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ documentation = "http://spherical-geometry.readthedocs.io/"
 requires = [
     "setuptools>=61.2",
     "setuptools_scm[toml]>=3.6",
-    "numpy>=1.25",
-#    "numpy>=2.0.0dev0",
+    #"numpy>=1.25",
+    "numpy>=2.0.0dev0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ documentation = "http://spherical-geometry.readthedocs.io/"
 requires = [
     "setuptools>=61.2",
     "setuptools_scm[toml]>=3.6",
-    #"numpy>=1.25",
-    "numpy>=2.0.0dev0",
+    "numpy>=1.25",
+    #"numpy>=2.0.0dev0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -19,8 +19,7 @@ from spherical_geometry.vector import two_d
 # the python versions are a fallback if the C cannot be used
 try:
     from spherical_geometry import math_util
-    math_util = None
-    HAS_C_UFUNCS = False
+    HAS_C_UFUNCS = True
 except ImportError:
     HAS_C_UFUNCS = False
 

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -196,7 +196,7 @@ def length(A, B):
     Returns
     -------
     length : scalar or array of scalars
-        The angular length of the great circle arc.
+        The angular length of the great circle arc in radians.
 
     Notes
     -----

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -546,8 +546,7 @@ class SingleSphericalPolygon(object):
             return np.array(0.0)
 
         points = np.vstack((self._points, self._points[1]))
-        angles = great_circle_arc.angle(points[:-2], points[1:-1],
-                                        points[2:], degrees=False)
+        angles = great_circle_arc.angle(points[:-2], points[1:-1], points[2:])
 
         return np.sum(angles) - (len(angles) - 2) * np.pi
 
@@ -704,7 +703,7 @@ class SingleSphericalPolygon(object):
 
         alpha = 1.0
         for A, B in zip(points[0:-1], points[1:]):
-            length = great_circle_arc.length(A, B, degrees=True)
+            length = np.rad2deg(great_circle_arc.length(A, B))
             if not np.isfinite(length):
                 length = 2
             interpolated = great_circle_arc.interpolate(A, B, length * 4)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -161,8 +161,6 @@ def test_interpolate():
         assert abs(length - first_length) < 1.0e-10
 
 
-@pytest.mark.xfail(
-    math_util is None, reason="math_util C-ext is missing, numpy gives different results")
 def test_overlap():
     def build_polygon(offset):
         points = []
@@ -380,26 +378,26 @@ def test_great_circle_arc_length():
     B = [-90, 0]
     A = vector.lonlat_to_vector(*A)
     B = vector.lonlat_to_vector(*B)
-    assert great_circle_arc.length(A, B) == 180.0
+    assert_almost_equal(great_circle_arc.length(A, B), np.pi)
 
     A = [135, 0]
     B = [-90, 0]
     A = vector.lonlat_to_vector(*A)
     B = vector.lonlat_to_vector(*B)
-    assert_almost_equal(great_circle_arc.length(A, B), 135.0)
+    assert_almost_equal(great_circle_arc.length(A, B), (3.0 / 4.0) * np.pi)
 
     A = [0, 0]
     B = [0, 90]
     A = vector.lonlat_to_vector(*A)
     B = vector.lonlat_to_vector(*B)
-    assert_almost_equal(great_circle_arc.length(A, B), 90.0)
+    assert_almost_equal(great_circle_arc.length(A, B), np.pi / 2.0)
 
 
 def test_great_circle_arc_angle():
     A = [1, 0, 0]
     B = [0, 1, 0]
     C = [0, 0, 1]
-    assert great_circle_arc.angle(A, B, C) == 270.0
+    assert great_circle_arc.angle(A, B, C) == (3.0 / 2.0) * np.pi
 
     # TODO: More angle tests
 
@@ -522,10 +520,9 @@ def test_convex_hull(repeat_pts):
         assert b == r, "Polygon boundary has correct points"
 
 
-@pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
 def test_math_util_angle_domain():
     assert not np.isfinite(
-        math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])[0]
+        great_circle_arc.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])[0]
     )
 
 
@@ -534,7 +531,6 @@ def test_math_util_length_domain():
         great_circle_arc.length([[np.nan, 0, 0]], [[0, 0, np.inf]])
 
 
-@pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
 def test_math_util_angle_nearly_coplanar_vec():
     # test from issue #222 + extra values
     vectors = [
@@ -542,7 +538,7 @@ def test_math_util_angle_nearly_coplanar_vec():
         5 * [[1, 0.9999999, 1]],
         [[1, 0.5, 1], [1, 0.15, 1], [1, 0.001, 1], [1, 0.15, 1], [-1, 0.1, -1]]
     ]
-    angles = math_util.angle(*vectors)
+    angles = great_circle_arc.angle(*vectors)
 
     assert_allclose(angles[:-1], np.pi, rtol=0, atol=1e-16)
     assert_allclose(angles[-1], 0, rtol=0, atol=1e-32)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -162,14 +162,16 @@ def test_interpolate():
 
 
 def test_overlap():
+    y_eps = 1e-8
+
     def build_polygon(offset):
         points = []
         corners = [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0)]
         for corner in corners:
-            point = np.asarray(corner)
-            point[0] += offset
-            points.append(np.asarray(vector.lonlat_to_vector(point[0],
-                                                             point[1])))
+            x, y = corner
+            points.append(
+                np.asarray(vector.lonlat_to_vector(x + offset, y + y_eps))
+            )
         poly = polygon.SphericalPolygon(points)
         return poly
 

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -529,10 +529,9 @@ def test_math_util_angle_domain():
     )
 
 
-@pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
 def test_math_util_length_domain():
     with pytest.raises(ValueError):
-        math_util.length([[np.nan, 0, 0]], [[0, 0, np.inf]])
+        great_circle_arc.length([[np.nan, 0, 0]], [[0, 0, np.inf]])
 
 
 @pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -18,6 +18,7 @@ from spherical_geometry.tests.helpers import ROOT_DIR, resolve_imagename
 
 try:
     from spherical_geometry import math_util
+    math_util = None
 except ImportError:
     math_util = None
 
@@ -332,9 +333,11 @@ def test_edge_crossings():
 
 
 @pytest.mark.skipif(
-    math_util is None, reason="math_util C-ext is missing, double accuracy leads to crash")
+    math_util is None,
+    reason="math_util C-ext is missing, double accuracy leads to crash"
+)
 def test_almost_identical_polygons_multi_union():
-    filename = resolve_imagename(ROOT_DIR,'almost_same_polygons.npz')
+    filename = resolve_imagename(ROOT_DIR, 'almost_same_polygons.npz')
     polygon_data = np.load(filename)
 
     polygons = []

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -18,7 +18,6 @@ from spherical_geometry.tests.helpers import ROOT_DIR, resolve_imagename
 
 try:
     from spherical_geometry import math_util
-    math_util = None
 except ImportError:
     math_util = None
 

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -331,8 +331,8 @@ def test_edge_crossings():
     _ = A.union(B)
 
 
-@pytest.mark.xfail(
-    math_util is None, reason="math_util C-ext is missing, numpy gives different results")
+@pytest.mark.skipif(
+    math_util is None, reason="math_util C-ext is missing, double accuracy leads to crash")
 def test_almost_identical_polygons_multi_union():
     filename = resolve_imagename(ROOT_DIR,'almost_same_polygons.npz')
     polygon_data = np.load(filename)

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -71,6 +71,8 @@ typedef struct {
     double x[4];
 } qd;
 
+#define ISNAN_QD(q) ((q.x[0]) != (q.x[0]))
+
 double QD_ONE[4] = {1.0, 0.0, 0.0, 0.0};
 
 static NPY_INLINE void
@@ -234,7 +236,15 @@ sign(const double A) {
 
 static NPY_INLINE int
 equals_qd(const qd *A, const qd *B) {
-    return memcmp(A, B, sizeof(qd) * 3) == 0;
+    if (memcmp(A, B, sizeof(qd) * 3)) {
+        return 0;
+    }
+    for (int k = 0; k < 3; ++k) {
+        if (ISNAN_QD(A[k])) {
+            return 0;
+        }
+    }
+    return 1;
 }
 
 static NPY_INLINE int
@@ -252,7 +262,7 @@ length_qd(const qd *A, const qd *B, qd *l) {
 
     dot_qd(A, B, &s);
 
-    if (s.x[0] != s.x[0] ||
+    if (ISNAN_QD(s) ||
         s.x[0] < -1.0 ||
         s.x[0] > 1.0) {
         PyErr_SetString(PyExc_ValueError, "Out of domain for acos");


### PR DESCRIPTION
This PR should fix (for now some) errors in unit tests when C `math_util` is not available.

`length()` needs more investigation (but the biggest difference in how `nan` are treated in comparisons: C code considers two `nan` equal) and I will do that in about 1 week from now.

Fix #261

CC: @jhunkeler @pllim