### PR TITLE
Fix memcmp invalid read

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 test = [
     "pytest",
     "pytest-astropy-header",
+    "pytest-timeout",
 ]
 docs = [
     "sphinx-automodapi",

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -214,6 +214,7 @@ def notest_difficult_unions():
     polygon.SphericalPolygon.multi_union(polys[:len(polys)//2])
 
 
+@pytest.mark.timeout(30)
 def test_inside_point():
     p = np.array(
         [[ 0.9990579 , -0.02407018,  0.03610999],

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -229,7 +229,7 @@ sign(const double A) {
 
 static NPY_INLINE int
 equals_qd(const qd *A, const qd *B) {
-    return memcmp(A, B, sizeof(qd) * 3) == 0;
+    return memcmp(A, B, sizeof(qd)) == 0;
 }
 
 static NPY_INLINE int


### PR DESCRIPTION
* memcmp(): Size cannot be larger than the source or destination object. (undefined behavior)

Merging this PR will break the following:
```
FAILED spherical_geometry/tests/test_basic.py::test_overlap - spherical_geometry.polygon.MalformedPolygonError: disjoint: find all intersections
FAILED spherical_geometry/tests/test_basic.py::test_great_circle_arc_length - assert 0.0 == 180.0
FAILED spherical_geometry/tests/test_basic.py::test_area - spherical_geometry.polygon.MalformedPolygonError: disjoint: find all intersections
FAILED spherical_geometry/tests/test_union.py::test_inside_point - Failed: Timeout >30.0s
```

`test_inside_point` enters an infinite loop, so a timeout was introduced to prevent hanging CI jobs for extended periods of time.

Ref: #262 #263 #265 