### PR TITLE
Update README to reflect bundled qd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Requirements
 
 - qd-library 2.3.7 or later (optional: if not available, the
   bundled version will be used).  To force using the system-installed
-  version, build with ``USE_SYSTEM_QD=1`` before building this package.
+  version, build with ``USE_SYSTEM_QD=1 pip install .``.
 
 Bundled qd-library
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -46,12 +46,12 @@ Requirements
 
 - qd-library 2.3.7 or later (optional: if not available, the
   bundled version will be used).  To force using the system-installed
-  version, build with ``USE_SYSTEM_QD=1 setup.py build``.
+  version, build with ``USE_SYSTEM_QD=1`` before building this package.
 
 Bundled qd-library
 ------------------
 
-Origin: https://www.davidhbailey.com/dhbsoftware/qd-2.3.22.tar.gz
+Origin: https://www.davidhbailey.com/dhbsoftware/qd-2.3.24.tar.gz
 
 - A custom ``libqd/include/qd/qd_config.h`` is provided to circumvent the need
   to run any configuration scripts. This generalized configuration may not be


### PR DESCRIPTION
* `setup.py build` is legacy command.
* qd has been bumped in #258 