### PR TITLE
TST: Option to disable using C-extension for debugging

### DIFF
--- a/.github/workflows/spherical_geometry.yml
+++ b/.github/workflows/spherical_geometry.yml
@@ -57,3 +57,11 @@ jobs:
         - name: Python 3.12 with dev version of dependencies (numpy 2.x)
           linux: py312-test-devdeps-numpy2x
           posargs: -v
+
+        - name: Python 3.11 without C-ext
+          linux: py311-test-disablecufuncs
+          posargs: -v
+
+        - name: Python 3.12 with dev version of dependencies without C-ext (numpy 2.x)
+          linux: py312-test-disablecufuncs-devdeps-numpy2x
+          posargs: -v

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Release Notes
   correctly with the ``math_util`` module and add unnecessary
   complication. [#265]
 
+- Setting ``export DISABLE_SPHR_GEOM_C_UFUNCS=true`` in your shell environment
+  now disables using ``math_util`` C-extension even when it is available.
+  This is useful for development and debugging. [#268]
+
 
 1.3.1 (5-November-2023)
 =======================

--- a/conftest.py
+++ b/conftest.py
@@ -20,3 +20,18 @@ PYTEST_HEADER_MODULES.pop('Pandas', None)
 PYTEST_HEADER_MODULES.pop('h5py', None)
 
 TESTED_VERSIONS['spherical-geometry'] = version
+
+
+# This has to be in the root dir or it will not display in CI.
+def pytest_report_header(config):
+    import os
+
+    from spherical_geometry import DISABLE_C_UFUNCS, HAS_C_UFUNCS
+
+    # This gets added after the pytest-astropy-header output.
+    return (
+        f'CI: {os.environ.get("CI", "undefined")}\n'
+        f'DISABLE_SPHR_GEOM_C_UFUNCS: {os.environ.get("DISABLE_SPHR_GEOM_C_UFUNCS", "undefined")}\n'
+        f'DISABLE_C_UFUNCS: {DISABLE_C_UFUNCS}\n'
+        f'HAS_C_UFUNCS: {HAS_C_UFUNCS}\n'
+    )

--- a/spherical_geometry/__init__.py
+++ b/spherical_geometry/__init__.py
@@ -1,4 +1,19 @@
+import os
+
+__all__ = ["__version__", "HAS_C_UFUNCS"]
+
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = ''
+
+
+DISABLE_C_UFUNCS = os.environ.get("DISABLE_SPHR_GEOM_C_UFUNCS", "false") == "true"
+if DISABLE_C_UFUNCS:
+    HAS_C_UFUNCS = False
+else:
+    try:
+        from . import math_util  # noqa: F401
+        HAS_C_UFUNCS = True
+    except ImportError:
+        HAS_C_UFUNCS = False

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -14,14 +14,9 @@ import numpy as np
 
 # LOCAL
 from spherical_geometry.vector import two_d
-
-# C versions of the code have been written to speed up operations
+# HAS_C_UFUNCS: C versions of the code have been written to speed up operations
 # the python versions are a fallback if the C cannot be used
-try:
-    from spherical_geometry import math_util
-    HAS_C_UFUNCS = True
-except ImportError:
-    HAS_C_UFUNCS = False
+from spherical_geometry import HAS_C_UFUNCS
 
 __all__ = ['angle', 'interpolate', 'intersection', 'intersects',
            'intersects_point', 'length', 'midpoint']
@@ -32,6 +27,7 @@ def _inner1d_np(x, y):
 
 
 if HAS_C_UFUNCS:
+    from spherical_geometry import math_util
     inner1d = math_util.inner1d
 else:
     inner1d = _inner1d_np

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -7,17 +7,12 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_allclose
 
-from spherical_geometry import graph, great_circle_arc, polygon, vector
+from spherical_geometry import graph, great_circle_arc, polygon, vector, HAS_C_UFUNCS
 from spherical_geometry.tests.helpers import (
     ROOT_DIR,
     get_point_set,
     resolve_imagename
 )
-
-try:
-    from spherical_geometry import math_util
-except ImportError:
-    math_util = None
 
 graph.DEBUG = True
 
@@ -522,18 +517,18 @@ def test_convex_hull(repeat_pts):
         assert b == r, "Polygon boundary has correct points"
 
 
-def test_math_util_angle_domain():
+def test_gca_angle_domain():
     assert not np.isfinite(
         great_circle_arc.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])[0]
     )
 
 
-def test_math_util_length_domain():
+def test_gca_length_domain():
     with pytest.raises(ValueError):
         great_circle_arc.length([[np.nan, 0, 0]], [[0, 0, np.inf]])
 
 
-def test_math_util_angle_nearly_coplanar_vec():
+def test_gca_angle_nearly_coplanar_vec():
     # test from issue #222 + extra values
     vectors = [
         5 * [[1.0, 1.0, 1.0]],
@@ -559,8 +554,9 @@ def test_inner1d():
     assert_allclose(lengths, [3.0, 1.0, 2.25, 2.0225, 2.01], rtol=0, atol=1e-15)
 
 
-@pytest.mark.skipif(math_util is None, reason="math_util C-ext is missing")
+@pytest.mark.skipif(not HAS_C_UFUNCS, reason="math_util C-ext is missing")
 def test_math_util_inner1d():
+    from spherical_geometry import math_util
     vectors = [
         [1.0, 1.0, 1.0],
         3 * [1.0 / np.sqrt(3)],

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -13,13 +13,8 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 
 # LOCAL
-from spherical_geometry import polygon
+from spherical_geometry import polygon, HAS_C_UFUNCS
 from spherical_geometry.tests.helpers import ROOT_DIR, resolve_imagename
-
-try:
-    from spherical_geometry import math_util
-except ImportError:
-    math_util = None
 
 GRAPH_MODE = False
 
@@ -332,7 +327,7 @@ def test_edge_crossings():
 
 
 @pytest.mark.skipif(
-    math_util is None,
+    not HAS_C_UFUNCS,
     reason="math_util C-ext is missing, double accuracy leads to crash"
 )
 def test_almost_identical_polygons_multi_union():

--- a/spherical_geometry/vector.py
+++ b/spherical_geometry/vector.py
@@ -8,11 +8,7 @@ vectors and converting them to and from other representations.
 # THIRD-PARTY
 import numpy as np
 
-try:
-    from . import math_util
-    HAS_C_UFUNCS = True
-except ImportError:
-    HAS_C_UFUNCS = False
+from spherical_geometry import HAS_C_UFUNCS
 
 __all__ = ['two_d', 'lonlat_to_vector', 'vector_to_lonlat',
            'normalize_vector', 'radec_to_vector', 'vector_to_radec',
@@ -149,6 +145,7 @@ def normalize_vector(xyz, output=None):
         output = np.empty(xyz.shape, dtype=np.float64)
 
     if HAS_C_UFUNCS:
+        from spherical_geometry import math_util
         math_util.normalize(xyz, output)
         return output
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{,-devdeps,-numpy2x}{,-cov}
+    py{39,310,311,312}-test{,-disablecufuncs}{,-devdeps}{,-numpy2x}{,-cov}
     codestyle
     twine
     bandit
@@ -11,6 +11,8 @@ passenv = HOME,WINDIR,CC,CI
 
 setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    disablecufuncs: DISABLE_SPHR_GEOM_C_UFUNCS=true
+    !disablecufuncs: DISABLE_SPHR_GEOM_C_UFUNCS=false
 
 # Run the tests in a temporary directory to make sure that we don't import
 # package from the source tree


### PR DESCRIPTION
Maybe sometimes we want to see if tests behave the same with or without C-extensions.