### PR TITLE
TST: Cancel duplicate wheel builds

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,6 +14,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
I noticed that some wheels are taking a long time. Then I realized they are behind in a queue. Duplicate builds should get cancelled. This is common situation when you enable wheel builds in PRs.