### PR TITLE
require numpy released ver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ documentation = "http://spherical-geometry.readthedocs.io/"
 requires = [
     "setuptools>=61.2",
     "setuptools_scm[toml]>=3.6",
-    "numpy>=2.0.0rc2",
+    "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
require released version of numpy instead of RC.

CC: @zacharyburnett 