### PR TITLE
update minimum required versions, add 3.13

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,7 +34,7 @@ jobs:
       test_extras: test
       test_command: pytest -p no:warnings --pyargs spherical_geometry.tests -v
       targets: |
-        - cp39-manylinux_x86_64
+        - cp311-manylinux_x86_64
 
 
   build_and_publish:

--- a/.github/workflows/spherical_geometry.yml
+++ b/.github/workflows/spherical_geometry.yml
@@ -37,23 +37,23 @@ jobs:
         - name: PEP 8
           linux: codestyle
 
-        - name: Python 3.9 (OSX)
-          macos: py39-test
+        - name: Python 3.11 (OSX)
+          macos: py311-test
           posargs: -v
 
-        - name: Python 3.10 (Windows)
-          windows: py310-test
+        - name: Python 3.12 (Windows)
+          windows: py312-test
           posargs: -v
 
-        - name: Python 3.11 with coverage
-          linux: py311-test-cov
+        - name: Python 3.13 with coverage
+          linux: py313-test-cov
           posargs: -v
           coverage: codecov
 
-        - name: Python 3.12 with dev version of dependencies
-          linux: py312-test-devdeps
+        - name: Python 3.13 with dev version of dependencies
+          linux: py313-test-devdeps
           posargs: -v
 
-        - name: Python 3.12 with dev version of dependencies (numpy 2.x)
-          linux: py312-test-devdeps-numpy2x
+        - name: Python 3.13 with dev version of dependencies (numpy 2.x)
+          linux: py313-test-devdeps-numpy2x
           posargs: -v

--- a/.github/workflows/spherical_geometry.yml
+++ b/.github/workflows/spherical_geometry.yml
@@ -50,10 +50,11 @@ jobs:
           posargs: -v
           coverage: codecov
 
+        - name: Python 3.13 with numpy 1.x
+          linux: py313-test-cov-numpy1x
+          posargs: -v
+          coverage: codecov
+
         - name: Python 3.13 with dev version of dependencies
           linux: py313-test-devdeps
-          posargs: -v
-
-        - name: Python 3.13 with dev version of dependencies (numpy 2.x)
-          linux: py313-test-devdeps-numpy2x
           posargs: -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "STScI", email = "help@stsci.edu" }
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
@@ -29,8 +29,8 @@ keywords = [
     "geometry",
 ]
 dependencies = [
-    "numpy>=1.23",
-    "astropy>=5.0.4",
+    "numpy>=1.25",
+    "astropy>=5.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313}-test{,-devdeps,-numpy2x}{,-cov}
+    py{311,312,313}-test{,-devdeps,-numpy1x}{,-cov}
     codestyle
     twine
     bandit
@@ -33,8 +33,7 @@ deps =
     # The devdeps factor is intended to be used to install the latest
     # developer version or nightly wheel of key dependencies.
     devdeps: astropy>=0.0.dev0
-    !numpy2x: numpy==1.*
-    numpy2x: numpy>=2.0.0.dev0
+    numpy1x: numpy==1.*
     cov: pytest-cov
 
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{,-devdeps,-numpy2x}{,-cov}
+    py{311,312,313}-test{,-devdeps,-numpy2x}{,-cov}
     codestyle
     twine
     bandit


### PR DESCRIPTION
Adds 3.13 testing to the CI
Updates minimum required versions of python (to 3.11) and numpy (to 1.25) and astropy (to 5.2.0) per [SPEC0](https://scientific-python.org/specs/spec-0000/)

Branch protections will need to be updated to merge this PR as the required jobs used old python versions.