### PR TITLE
consistent CI and pre-commit config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-extend-ignore = E201,E202,E203,E221,E231,E741

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Wheel building
+name: build
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
       - labeled
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
 
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 jobs:
-  test_wheel_building:
+  build_quick:
     # This ensures that a couple of targets work fine in pull requests
     permissions:
       contents: none
@@ -31,15 +31,11 @@ jobs:
     with:
       upload_to_pypi: false
       upload_to_anaconda: false
-      test_extras: test
-      test_command: pytest -p no:warnings --pyargs spherical_geometry.tests -v
       targets: |
         - cp311-manylinux_x86_64
-
-
-  build_and_publish:
+  build:
     # This job builds the wheels and publishes them to PyPI for all
-    # tags. For PRs with the "Build wheels" label, wheels are built,
+    # releases. For PRs with the "Build wheels" label, wheels are built,
     # but are not uploaded to PyPI.
 
     permissions:
@@ -47,15 +43,12 @@ jobs:
 
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v2
 
-    if: (github.repository == 'spacetelescope/spherical_geometry' && (github.event_name == 'push' ||  contains(github.event.pull_request.labels.*.name, 'Build wheels')))
+    if: (github.repository == 'spacetelescope/spherical_geometry' && (((github.event_name == 'release') && (github.event.action == 'released')) ||  contains(github.event.pull_request.labels.*.name, 'Build wheels')))
     with:
-      # We upload to PyPI for all tag pushes
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'push' }}
+      upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
 
       # BUG: https://github.com/spacetelescope/spherical_geometry/issues/244
       # BUG: https://github.com/spacetelescope/spherical_geometry/issues/245
-      test_extras: test
-      test_command: pytest -p no:warnings --pyargs spherical_geometry.tests -v
       targets: |
         # Linux wheels
         - cp3*-manylinux_x86_64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   schedule:
     # Run every Monday at 6am UTC
-    - cron: '0 6 * * 1'
+    - cron: "0 6 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       submodules: false
-      coverage: ''
+      coverage: ""
       envs: |
         - name: Python 3.11
           linux: py311-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
-name: CI
+name: test
 
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -27,16 +27,6 @@ jobs:
       submodules: false
       coverage: ''
       envs: |
-        # Make sure that packaging will work
-        - name: pep517 build
-          linux: twine
-
-        - name: Security audit
-          linux: bandit
-
-        - name: PEP 8
-          linux: codestyle
-
         - name: Python 3.11
           linux: py311-test
           posargs: -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+ci:
+  autofix_prs: false
+  autoupdate_schedule: monthly
+
+exclude: ".*\\.asdf$"
+
+repos:
+  # basic checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-yaml
+        args:
+          - --unsafe
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: debug-statements
+      - id: detect-private-key
+      # - id: end-of-file-fixer
+      # - id: trailing-whitespace
+  # simple text searches for common issues
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char
+  # lint and format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.11
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+          - --show-fixes
+  #     - id: ruff-format
+  # # type checking
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.17.1
+  #   hooks:
+  #     - id: mypy
+  # # spell-checking
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: v2.4.1
+  #   hooks:
+  #     - id: codespell
+  #       args:
+  #         - --write-changes
+  #         - --summary
+  #       additional_dependencies:
+  #         - tomli
+  # format YAML and Markdown
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
+    hooks:
+      - id: prettier
+        types_or:
+          - yaml
+          - markdown
+  # format TOML
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,9 +12,9 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   builder: html
-   configuration: docs/conf.py
-   fail_on_warning: false
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: false
 
 python:
   install:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,6 @@
 # Spacetelescope Open Source Code of Conduct
 
-We expect all "spacetelescope" organization projects to adopt a code of conduct that ensures a productive, respectful environment for all open source contributors and participants. We are committed to providing a strong and enforced code of conduct and expect everyone in our community to follow these guidelines when interacting with others in all forums. Our goal is to keep ours a positive, inclusive, successful, and growing community. The community of participants in open source Astronomy projects is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth. 
-
+We expect all "spacetelescope" organization projects to adopt a code of conduct that ensures a productive, respectful environment for all open source contributors and participants. We are committed to providing a strong and enforced code of conduct and expect everyone in our community to follow these guidelines when interacting with others in all forums. Our goal is to keep ours a positive, inclusive, successful, and growing community. The community of participants in open source Astronomy projects is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth.
 
 As members of the community,
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,9 @@ filterwarnings = [
             # Don't complain about IPython completion helper
             "def _ipython_key_completions_",
         ]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+extend-ignore = ["E201", "E202", "E203", "E221", "E231", "E741"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,47 +1,34 @@
 [project]
 name = "spherical_geometry"
-dynamic = [
-    "version"
-]
+dynamic = ["version"]
 description = "Python based tools for spherical geometry"
 readme = "README.rst"
-authors = [
-    { name = "STScI", email = "help@stsci.edu" }
-]
+authors = [{ name = "STScI", email = "help@stsci.edu" }]
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.11"
 classifiers = [
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
-    "Programming Language :: C",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Topic :: Scientific/Engineering :: Astronomy",
-    "Topic :: Scientific/Engineering :: Physics",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: C",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Scientific/Engineering :: Astronomy",
+  "Topic :: Scientific/Engineering :: Physics",
 ]
 keywords = [
-    "astronomy",
-    "astrophysics",
-    "space",
-    "science",
-    "spherical",
-    "geometry",
+  "astronomy",
+  "astrophysics",
+  "space",
+  "science",
+  "spherical",
+  "geometry",
 ]
-dependencies = [
-    "numpy>=1.25",
-    "astropy>=5.2.0",
-]
+dependencies = ["numpy>=1.25", "astropy>=5.2.0"]
 
 [project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-astropy-header",
-]
-docs = [
-    "sphinx-automodapi",
-    "numpydoc",
-]
+test = ["pytest", "pytest-astropy-header"]
+docs = ["sphinx-automodapi", "numpydoc"]
 
 [project.urls]
 bug = "https://github.com/spacetelescope/spherical_geometry/issues/"
@@ -50,11 +37,7 @@ help = "https://hsthelp.stsci.edu"
 documentation = "http://spherical-geometry.readthedocs.io/"
 
 [build-system]
-requires = [
-    "setuptools>=61.2",
-    "setuptools_scm[toml]>=3.6",
-    "numpy>=2.0.0",
-]
+requires = ["setuptools>=61.2", "setuptools_scm[toml]>=3.6", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -67,13 +50,8 @@ include = ["spherical_geometry*"]
 namespaces = false
 
 [tool.setuptools.package-data]
-"*" = [
-    "README.rst",
-    "licenses/*",
-]
-"spherical_geometry.tests" = [
-    "data/*",
-]
+"*" = ["README.rst", "licenses/*"]
+"spherical_geometry.tests" = ["data/*"]
 
 [tool.setuptools_scm]
 write_to = "spherical_geometry/_version.py"
@@ -81,46 +59,38 @@ write_to = "spherical_geometry/_version.py"
 [tool.pytest.ini_options]
 minversion = 6.0
 addopts = "--color=yes --import-mode=append"
-testpaths = [
-    "spherical_geometry",
-]
-norecursedirs = [
-    "build",
-    "docs[\\/]_build",
-]
+testpaths = ["spherical_geometry"]
+norecursedirs = ["build", "docs[\\/]_build"]
 astropy_header = true
 junit_family = "xunit2"
 xfail_strict = true
 filterwarnings = [
-    "error",
-    "ignore:numpy\\.ndarray size changed:RuntimeWarning",
-    "ignore:numpy\\.ufunc size changed:RuntimeWarning",
+  "error",
+  "ignore:numpy\\.ndarray size changed:RuntimeWarning",
+  "ignore:numpy\\.ufunc size changed:RuntimeWarning",
 ]
 
 [tool.coverage]
 
-    [tool.coverage.run]
-        omit = [
-            "spherical_geometry/tests/*",
-            "*/spherical_geometry/tests/*",
-        ]
+[tool.coverage.run]
+omit = ["spherical_geometry/tests/*", "*/spherical_geometry/tests/*"]
 
-    [tool.coverage.report]
-        exclude_lines = [
-            # Have to re-enable the standard pragma
-            "pragma: no cover",
-            # Don't complain about packages we have installed
-            "except ImportError",
-            # Don't complain if tests don't hit defensive assertion code:
-            "raise AssertionError",
-            "raise NotImplementedError",
-            # Don't complain about script hooks
-            "'def main(.*):'",
-            # Ignore branches that don't pertain to this version of Python
-            "pragma: py{ignore_python_version}",
-            # Don't complain about IPython completion helper
-            "def _ipython_key_completions_",
-        ]
+[tool.coverage.report]
+exclude_lines = [
+  # Have to re-enable the standard pragma
+  "pragma: no cover",
+  # Don't complain about packages we have installed
+  "except ImportError",
+  # Don't complain if tests don't hit defensive assertion code:
+  "raise AssertionError",
+  "raise NotImplementedError",
+  # Don't complain about script hooks
+  "'def main(.*):'",
+  # Ignore branches that don't pertain to this version of Python
+  "pragma: py{ignore_python_version}",
+  # Don't complain about IPython completion helper
+  "def _ipython_key_completions_",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -1,73 +1,34 @@
 [tox]
-envlist =
+env_list =
     py{311,312,313}-test{,-devdeps,-numpy1x}{,-cov}
-    codestyle
-    twine
-    bandit
 
 [testenv]
-# Pass through the following environment variables which are needed for the CI
-passenv = HOME,WINDIR,CC,CI
-
-setenv =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-
-# Run the tests in a temporary directory to make sure that we don't import
-# package from the source tree
-changedir = .tmp/{envname}
-
-# tox environments are constructued with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
 description =
     run tests
     devdeps: with the latest developer version of key dependencies
     cov: and test coverage
-
-deps =
-    # The devdeps factor is intended to be used to install the latest
-    # developer version or nightly wheel of key dependencies.
-    devdeps: astropy>=0.0.dev0
-    numpy1x: numpy==1.*
-    cov: pytest-cov
-
+    xdist: using parallel processing
+pass_env =
+    HOME
+    WINDIR
+    CC
+    CI
+set_env =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+# Run the tests in a temporary directory to make sure that we don't import package from the source tree
+changedir = .tmp/{envname}
 extras =
     test
-
-commands =
-    pip freeze
-    !cov: pytest --pyargs spherical_geometry {posargs}
-    cov: pytest --pyargs spherical_geometry --cov spherical_geometry --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
-
-[testenv:codestyle]
-skip_install = true
-changedir = {toxinidir}
-description = check code style with flake8
-deps = flake8
-commands = flake8 spherical_geometry --count
-
-[testenv:twine]
-skip_install = true
-changedir = {toxinidir}
-description = twine check dist tarball
 deps =
-    build
-    twine>=3.3
+    devdeps: astropy>=0.0.dev0
+    cov: pytest-cov
+    numpy1x: numpy==1.*
+    xdist: pytest-xdist
+commands_pre =
+    pip list
 commands =
-    pip freeze
-    python -m build --sdist .
-    twine check --strict dist/*
-
-[testenv:bandit]
-skip_install = true
-changedir = {toxinidir}
-description = Security audit with bandit
-deps = bandit
-commands =
-    pip freeze
-    bandit spherical_geometry -r -x spherical_geometry/tests
+    pytest \
+    --pyargs spherical_geometry \
+    cov: --cov --cov-config {toxinidir}/pyproject.toml --cov-report term-missing --cov-report xml \
+    xdist: -n 0 \
+    {posargs}


### PR DESCRIPTION
update CI to be consistent with other pipeline repositories, and add a `pre-commit` configuration for linting. Also, port `.flake8` to `pyproject.toml` so we can start using `ruff` with the same rules. After merging, I'll update the branch protection rules to remove the required status checks that no longer exist