### PR TITLE
add py313 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,10 @@ jobs:
           linux: py312-test
           posargs: -v
 
+        - name: Python 3.13
+          linux: py313-test
+          posargs: -v
+
         # `tox` does not currently respect `requires-python` versions when creating testing environments;
         # if this breaks, add an upper pin to `requires-python` and revert this py3 to the latest working version
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 env_list =
-    py{311,312,313}-test{,-devdeps,-numpy1x}{,-cov}
+    py{311,312,313,314}-test{,-devdeps,-numpy1x}{,-cov}
 
 [testenv]
 description =


### PR DESCRIPTION
Since py3 is now py314 the CI does not test with python 3.13.

This PR add python 3.13 tests.