### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = [
 dependencies = ["numpy>=1.25", "astropy>=5.2.0"]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-astropy-header"]
+test = ["pytest>=9.0", "pytest-astropy-header"]
 docs = ["sphinx-automodapi", "numpydoc"]
 
 [project.urls]
@@ -56,9 +56,9 @@ namespaces = false
 [tool.setuptools_scm]
 write_to = "spherical_geometry/_version.py"
 
-[tool.pytest.ini_options]
-minversion = 6.0
-addopts = "--color=yes --import-mode=append"
+[tool.pytest]
+minversion = "9.0"
+addopts = ["--color=yes", "--import-mode=append"]
 testpaths = ["spherical_geometry"]
 norecursedirs = ["build", "docs[\\/]_build"]
 astropy_header = true


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`