### PR TITLE
Detect degenerate polygons and exclude them from unions and intersections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,9 +24,6 @@ Release Notes
 - Polygon unions and intersections now filter out degenerate polygons in input
   arguments before processing. [#316]
 
-- Added a new method ``is_degenerate()`` to check if a polygon is
-  degenerate. [#316]
-
 
 1.3.5 (17-February-2026)
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,15 +4,36 @@
 Release Notes
 =============
 
-1.3.6 (unreleased)
+
+1.4.0 (unreleased)
 ==================
 
-- Make ``astropy`` an optional dependency
+- Make ``astropy`` an optional dependency. [#315]
+
+- Fixed a bug in ``SingleSphericalPolygon.is_clockwise`` that caused it
+  to always report `False` for polygons with points on a great circle. Updated
+  the code to detect degenerate polygons and return `None` in such
+  cases. [#316]
+
+- Area of degenerate polygons is now defined to be zero. [#316]
+
+- Degenerate polygons are now considered to contain no ``inside`` point. [#316]
+
+- ``invert_polygon()`` returns `None` for degenerate polygons. [#316]
+
+- Polygon unions and intersections now filter out degenerate polygons in input
+  arguments before processing. [#316]
+
+- Added a new method ``is_degenerate()`` to check if a polygon is
+  degenerate. [#316]
+
 
 1.3.5 (17-February-2026)
 ========================
 
 - Update ``from_wcs`` to accept any WCS object that implements the WCS API.
+  [#301]
+
 
 1.3.4 (06-November-2025)
 ========================

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -189,7 +189,7 @@ class Graph:
         """
         points = polygon._points
 
-        if len(points) < 3:
+        if len(points) < 4 or polygon._degenerate:
             return
 
         self._source_polygons.add(polygon)

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -146,16 +146,20 @@ class SingleSphericalPolygon(object):
         # the points lie almost in a plane through the origin.
         return w1 < tol * w3
 
-    def is_degenerate(self):
-        """
-        Return `True` if the polygon is degenerate (i.e., has no points,
-        or is otherwise invalid).
-        """
-        # If we want to compute this at runtime, we can check whether
-        # the points are all on a great circle (too expensive to do in general,
-        # so we compute it at initialization and store the result).
-        # return self._is_clockwise() is None
-        return self._degenerate
+    # TODO: Not sure if we want to make this a public method since in the
+    #       future we might not allow instantiation of degenerate polygons
+    #       at all. For more info, see:
+    # https://github.com/spacetelescope/spherical_geometry/pull/316#discussion_r2834501132
+    #
+    # def is_degenerate(self):
+    #     """
+    #     Return `True` if the polygon is degenerate (i.e., has no points,
+    #     or is otherwise invalid).
+    #     """
+    #     # If we want to compute this at runtime, we can check whether
+    #     # the points are all on a great circle (too expensive to do in general,
+    #     # so we compute it at initialization and store the result).
+    #     return self._degenerate
 
     def _get_orient(self, compute_inside=False):
         npoints = len(self._points)
@@ -882,14 +886,14 @@ class SphericalPolygon(SingleSphericalPolygon):
         for polygon in init:
             if not isinstance(polygon, (SphericalPolygon, SingleSphericalPolygon)):
                 break
-            if polygon.is_degenerate():
+            if polygon._degenerate:
                 self._degenerate = True
         else:
             self._polygons = tuple(init)
             return
 
         p = SingleSphericalPolygon(init, inside)
-        if p.is_degenerate():
+        if p._degenerate:
             self._degenerate = True
             self._polygons = tuple()
             return
@@ -900,7 +904,7 @@ class SphericalPolygon(SingleSphericalPolygon):
 
         polygons = []
         for polygon in self:
-            if polygon.is_degenerate():
+            if polygon._degenerate:
                 continue
             g = graph.Graph((polygon,))
             polygons.extend(g.disjoint_polygons())
@@ -1154,7 +1158,7 @@ class SphericalPolygon(SingleSphericalPolygon):
             Returns `True` if the polygon contains the given *point*.
             Returns `None` if the polygon is degenerate.
         """
-        if self.is_degenerate():
+        if self._degenerate:
             return None
         for polygon in self:
             if polygon.contains_point(point):
@@ -1181,7 +1185,7 @@ class SphericalPolygon(SingleSphericalPolygon):
             Returns `True` if the polygon contains the given *point*.
             Returns `None` if the polygon is degenerate.
         """
-        if self.is_degenerate():
+        if self._degenerate:
             return None
         for polygon in self:
             if polygon.contains_lonlat(lon, lat, degrees=degrees):
@@ -1212,7 +1216,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         if not isinstance(other, SphericalPolygon):
             raise TypeError
 
-        if self.is_degenerate() or other.is_degenerate():
+        if self._degenerate or other._degenerate:
             return None
 
         for polya in self:
@@ -1226,7 +1230,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         Determines if this `SphericalPolygon` intersects or contains
         the given arc. Returns `None` if the polygon is degenerate.
         """
-        if self.is_degenerate():
+        if self._degenerate:
             return None
         for subpolygon in self:
             if subpolygon.intersects_arc(a, b):
@@ -1238,7 +1242,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         Returns `True` if the polygon fully encloses the arc given by a
         and b. Returns `None` if the polygon is degenerate.
         """
-        if self.is_degenerate():
+        if self._degenerate:
             return None
         for subpolygon in self:
             if subpolygon.contains_arc(a, b):
@@ -1332,7 +1336,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         for polygon in polygons:
             if not isinstance(polygon, SphericalPolygon):
                 raise TypeError("Expected a sequence of SphericalPolygon")
-            if not polygon.is_degenerate():
+            if not polygon._degenerate:
                 valid_polygons.append(polygon)
 
         if not valid_polygons:
@@ -1366,10 +1370,10 @@ class SphericalPolygon(SingleSphericalPolygon):
 
         all_polygons = []
         for polygon in filtered_polygons:
-            if polygon.is_degenerate():
+            if polygon._degenerate:
                 continue
             for p in polygon:
-                if p.is_degenerate():
+                if p._degenerate:
                     continue
                 all_polygons.append(p)
 
@@ -1411,7 +1415,7 @@ class SphericalPolygon(SingleSphericalPolygon):
                     if subpolygons is None:
                         continue
                     for p in subpolygons:
-                        if p.is_degenerate():
+                        if p._degenerate:
                             continue
                         all_polygons.append(p)
 
@@ -1440,7 +1444,7 @@ class SphericalPolygon(SingleSphericalPolygon):
 
         results = None
         for polygon in polygons:
-            if results is None and not polygon.is_degenerate():
+            if results is None and not polygon._degenerate:
                 results = polygon
             elif len(results.polygons) == 0:
                 return results

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -760,7 +760,7 @@ def test_degenerate_polygon():
     p = polygon.SingleSphericalPolygon(points)
     assert p.is_clockwise() is None
     assert p.inside is None
-    assert p.is_degenerate()
+    assert p._degenerate
     assert p.area() == 0.0
 
     # Test that a polygon with all points the same is degenerate
@@ -768,12 +768,12 @@ def test_degenerate_polygon():
     p = polygon.SingleSphericalPolygon(points)
     assert p.is_clockwise() is None
     assert p.inside is None
-    assert p.is_degenerate()
+    assert p._degenerate
     assert p.area() == 0.0
 
     # Test that a polygon on a great circle is degenerate:
     p = polygon.SphericalPolygon.from_lonlat(90 * np.arange(5), 5 * [0])
-    assert p.is_degenerate()
+    assert p._degenerate
     assert p.is_clockwise() is None
     assert None in list(p.inside)
     assert p.area() == 0.0
@@ -785,5 +785,5 @@ def test_degenerate_polygon():
 
     assert p.is_clockwise()
     assert p.inside is not None
-    assert not p.is_degenerate()
+    assert not p._degenerate
     assert p.area() != 0.0

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -752,3 +752,38 @@ def test_math_util_inner1d():
     lengths = math_util.inner1d(vectors, vectors)
 
     assert_allclose(lengths, [3.0, 1.0, 2.25, 2.0225, 2.01], rtol=0, atol=1e-15)
+
+
+def test_degenerate_polygon():
+    # Test that a polygon with all points the same is degenerate
+    points = np.array(4 * [[1, 0, 0]])
+    p = polygon.SingleSphericalPolygon(points)
+    assert p.is_clockwise() is None
+    assert p.inside is None
+    assert p.is_degenerate()
+    assert p.area() == 0.0
+
+    # Test that a polygon with all points the same is degenerate
+    points = np.array([[1, 0, 0], [0, 1, 0], [-1, 0, 0]])
+    p = polygon.SingleSphericalPolygon(points)
+    assert p.is_clockwise() is None
+    assert p.inside is None
+    assert p.is_degenerate()
+    assert p.area() == 0.0
+
+    # Test that a polygon on a great circle is degenerate:
+    p = polygon.SphericalPolygon.from_lonlat(90 * np.arange(5), 5 * [0])
+    assert p.is_degenerate()
+    assert p.is_clockwise() is None
+    assert None in list(p.inside)
+    assert p.area() == 0.0
+
+    # Test that a polygon close to but not on a great circle is not degenerate:
+    z = np.sin(np.deg2rad(1e-9))
+    pts = np.array([[1, 0, z], [0, 1, z], [-1, 0, z], [0, -1, z], [1, 0, z]])
+    p = polygon.SingleSphericalPolygon(pts)
+
+    assert p.is_clockwise()
+    assert p.inside is not None
+    assert not p.is_degenerate()
+    assert p.area() != 0.0

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -71,7 +71,7 @@ class intersection_test:
                 assert np.all(intersection_area * 0.9 <= areas)
 
             lengths = np.array([
-                sum(len(x._points) for x in y.iter_polygons_flat())
+                sum(len(x._points) for x in y)
                 for y in intersections])
             assert np.all(lengths == [lengths[0]])
             areas = np.array([x.area() for x in intersections])
@@ -268,7 +268,7 @@ def test_ordering():
             points = p.points
             points = np.roll(points[:-1], i, 0)
             points = np.append(points, [points[0]], 0)
-            p = polygon._SingleSphericalPolygon(points, p.inside)
+            p = polygon.SingleSphericalPolygon(points, p.inside)
             polygons.append(p)
         return polygon.SphericalPolygon(polygons)
 

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -78,7 +78,7 @@ class union_test:
                 assert np.all(union_area * 1.1 >= areas)
 
             lengths = np.array([
-                sum(len(x._points) for x in y.iter_polygons_flat())
+                sum(len(x._points) for x in y)
                 for y in unions])
             assert np.all(lengths == [lengths[0]])
             areas = np.array([x.area() for x in unions])
@@ -363,5 +363,6 @@ def test_almost_identical_polygons_multi_union():
         p_shapes = [(66, 3)]
 
     p = polygon.SphericalPolygon.multi_union(polygons)
+
     assert np.shape(list(p.points)[0]) in p_shapes
     assert abs(p.area() - 2.6672666e-8) < area_tol


### PR DESCRIPTION
Fixes #147

Specifically, this PR implements a couple of improvements to the code by detecting and removing, when necessary (such as in computing unions and intersections or creating a "multi-polygon"), degenerate polygons: polygons with fewer than 4 points (when closed, `p1 == p4`) or when supplied vertices lie on a great circle.

For degenerate polygons, `is_clockwise`, `inside` will return `None` and `area` will return 0 which is different from current behavior that returns `2*pi` for area which is incorrect.

Also, removed deprecated classes `_SingleSphericalPolygon` and `_SphericalPolygon` (note to myself - update changelog)