### PR TITLE
fix definition of center point in `from_wcs()`

### DIFF
--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -322,7 +322,7 @@ class SingleSphericalPolygon(object):
         # convert the pixel indices into sky coordinates using the WCS
         vertex_skycoords = wcs.pixel_to_world(*vertex_indices.T)
         center_skycoord = wcs.pixel_to_world(
-            *(origin_indices + (origin_indices + array_shape) / 2)
+            *((np.array(array_shape) + origin_index) / 2 + origin_index)
         )
         center = center_skycoord.ra.degree, center_skycoord.dec.degree
 


### PR DESCRIPTION
not sure how this got past the tests (they all pass with or without this fix)

the center point should be a single lonlat, not lonlats for every vertex