### PR TITLE
Improve arc length and add unit tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,18 @@ Release Notes
 1.4.1 (unreleased)
 ==================
 
-- 
+- Improved stability of ``length()`` in the ``math_util`` and
+  ``great_circle_arc`` modules. [#322]
+
+- Changed default threshold for considering two nodes to be equal in
+  the ``graph`` module from 1e-9 to 1e-10 in the ``graph.Graph.Node.equals()``
+  method. Updated docstring. [#322]
+
+- Added debug functions for saving polygon parameters to a text file. These
+  functions are not intended for public use. [#322]
+
+- Aded two unit tests based on #292 (and possibly #278)that are marked
+  with ``xfail`` for now. [#322]
 
 
 1.4.0 (2026-03-11)

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -11,6 +11,8 @@ import weakref
 # THIRD-PARTY
 import numpy as np
 
+from . import math_util
+
 # LOCAL
 from spherical_geometry import great_circle_arc as gca
 from spherical_geometry import vector
@@ -67,7 +69,7 @@ class Graph:
         def __repr__(self):
             return "Node(%s %d)" % (str(self._point), len(self._edges))
 
-        def equals(self, other, thresh=1.e-9):
+        def equals(self, other, thresh=1.0e-10):
             """
             Returns `True` if the location of this and the *other*
             `~Graph.Node` are the same.
@@ -77,13 +79,17 @@ class Graph:
             other : `~Graph.Node` instance
                 The other node.
 
-            thres : float
+            thresh : float
                 If difference is smaller than this, points are equal.
-                The default value of 2e-8 radians is set based on
+                The default value of 1e-10 radians is set based on
                 empirical test cases. Relative threshold based on
                 the actual sizes of polygons is not implemented.
             """
-            return np.array_equal(self._point, other._point)
+            # return np.array_equal(self._point, other._point)
+            return np.linalg.norm(self._point - other._point) < thresh
+            # Possibly more accurate but much slower.
+            # TODO: do more testing once the main stability issues are dealt with.
+            # return math_util.length(self._point, other._point) < thresh
 
     class Edge:
         """
@@ -236,6 +242,12 @@ class Graph:
             node_array = np.array([node._point for node in nodes])
 
             diff = np.all(np.abs(point - node_array) < 2 ** -32, axis=-1)
+            # TODO: consider using arccos: v1 . v2 = cos(angle), so angle = arccos(v1 . v2).
+            # diff = np.arccos(np.clip(node_array @ point, -1, 1)) < 4e-9
+            # TODO: even more accurate but slower (makes one xfailed test to
+            # pass and another test to fail that was expected to pass -
+            # different number of vertices):
+            # diff = gca.length(node_array, point) < 4e-10
 
             indices = np.nonzero(diff)[0]
             if len(indices):

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     HAS_C_UFUNCS = False
 
+
 __all__ = ['angle', 'interpolate', 'intersection', 'intersects',
            'intersects_point', 'length', 'midpoint']
 
@@ -209,31 +210,27 @@ def length(A, B):
     if HAS_C_UFUNCS:
         result = math_util.length(A, B)
     else:
-        approx1 = 1 + 3 * np.finfo(float).eps
+        # Original code used arccos of the dot product (arccos(a·b)), but this
+        # can be inaccurate for very small angles due to floating point
+        # precision. The following is more accurate both for small and large
+        # angles, but is more expensive to compute:
+        # length = arctan2(|a×b|, a·b)
         A = np.asanyarray(A)
         B = np.asanyarray(B)
 
-        A2 = A ** 2.0
-        Al = np.sqrt(np.sum(A2, axis=-1))
-        B2 = B ** 2.0
-        Bl = np.sqrt(np.sum(B2, axis=-1))
+        if np.any(np.all(A == 0, axis=-1)) or np.any(np.all(B == 0, axis=-1)):
+            raise ValueError("Null vector")
 
         try:
             with np.errstate(invalid='raise'):
-                A = A / two_d(Al)
-                B = B / two_d(Bl)
+                dot = inner1d(A, B)
         except FloatingPointError:
             raise ValueError("Out of domain for acos")
 
-        dot = inner1d(A, B)
+        A, B = np.broadcast_arrays(A, B)
+        cross = np.linalg.norm(_fast_cross(A, B), axis=-1)
 
-        for d in np.atleast_1d(dot):
-            if np.isnan(d) or abs(d) > approx1:
-                raise ValueError("Out of domain for acos")
-
-        dot = np.clip(dot, -1.0, 1.0)  # needed due to accuracy loss
-        with np.errstate(invalid='ignore'):
-            result = np.arccos(dot)
+        result = np.arctan2(cross, dot)
 
     return result
 

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -847,6 +847,20 @@ class SingleSphericalPolygon(object):
         x, y = m(lon, lat)
         m.scatter(x, y, 1, **plot_args)
 
+    def _debug_write(self, filename, mode='w'):
+        """
+        Write the polygon to a file for debugging purposes.  The file is
+        a simple text file with one line per point, and three columns
+        corresponding to *x*, *y* and *z*.
+        """
+        with open(filename, mode) as f:
+            f.write("# SingleSphericalPolygon\n")
+            f.write("# Inside Point (x, y, z):\n")
+            f.write(f"{self._inside[0]:.15g}, {self._inside[1]:.15g}, {self._inside[2]:.15g}\n")
+            f.write("# Vertices (x, y, z):\n")
+            for point in self._points:
+                f.write(f"{point[0]:.15g}, {point[1]:.15g}, {point[2]:.15g}\n")
+
 
 class SphericalPolygon(SingleSphericalPolygon):
     r"""
@@ -1465,3 +1479,12 @@ class SphericalPolygon(SingleSphericalPolygon):
         """
         for polygon in self._polygons:
             polygon.draw(m, **plot_args)
+
+    def _debug_write(self, filename):
+        """
+        Write the polygon to a file for debugging purposes.  The file is
+        a simple text file with one line per point, and three columns
+        corresponding to *x*, *y* and *z*.
+        """
+        for i, polygon in enumerate(self):
+            polygon._debug_write(filename, mode='w' if i == 0 else 'a')

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -710,6 +710,10 @@ def test_math_util_length_domain():
         [0, 0, 0],
     ]
 
+    for b_i in b:
+        with pytest.raises(ValueError):
+            great_circle_arc.length(a, b_i)
+
     with pytest.raises(ValueError):
         great_circle_arc.length(a, b)
 

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -381,7 +381,7 @@ def test_intersection_crash_similar_poly():
 
 
 # TODO make this test pass
-@pytest.mark.xfail(reason="https://github.com/spacetelescope/spherical_geometry/issues/278")  
+@pytest.mark.xfail(reason="https://github.com/spacetelescope/spherical_geometry/issues/278")
 def test_complement_regression():
     """https://github.com/spacetelescope/spherical_geometry/issues/278"""
 
@@ -456,3 +456,129 @@ def test_commutative_intersection(polygons):
     sorted_intersection_area = sorted_intersection.area()
 
     assert_allclose(unsorted_intersection_area, sorted_intersection_area)
+@pytest.mark.xfail(reason="currently there is no solution to get this to pass")
+def test_intersection_order_independent_from_large_cones():
+    """
+    Intersections of several polygons should be independent of the order of the
+    intersections, e.g., (A^B)^C should give the same result as (A^C)^B.
+
+    Based on user report in https://github.com/spacetelescope/spherical_geometry/issues/292
+    Possibly related to https://github.com/spacetelescope/spherical_geometry/issues/278
+
+    """
+    #TODO: It would be useful to check that intersection polygons have the same
+    # number of vertices and same vertex coordinates, although this can be
+    # tricky as theoretically these vertices could be partially different,
+    # e.g., some polygons could have extra vertices lying on the arc connecting
+    # two adjacent vertices that are present in both orders of intersection.
+    # These polygons would be equivalent but we currently do not a way to
+    # detect this.
+
+    cone0 = {'lat': 40.5785, 'lon': -122.4005, 'radius': 126.08093425137112}
+    cone1 = {'lat': -33.5605, 'lon': -70.5815, 'radius': 90.64909777330483}
+    cone2 = {'lat': 38.9005, 'lon': -77.0505, 'radius': 92.53797630605003}
+    cone3 = {'lat': 45.0905, 'lon': 7.6575, 'radius': 108.34122674041656}
+    cone4 = {'lat': -25.7795, 'lon': -56.4515, 'radius': 73.960984449381}
+
+    p0 = polygon.SphericalPolygon.from_cone(**cone0, degrees=True, steps=22)
+    p1 = polygon.SphericalPolygon.from_cone(**cone1, degrees=True, steps=22)
+    p2 = polygon.SphericalPolygon.from_cone(**cone2, degrees=True, steps=22)
+    p3 = polygon.SphericalPolygon.from_cone(**cone3, degrees=True, steps=22)
+    p4 = polygon.SphericalPolygon.from_cone(**cone4, degrees=True, steps=22)
+
+    # case 1 (theoretical area: 3.925526452880896):
+    theor_area = 3.925526452880896
+    p01_2 = (p0.intersection(p1)).intersection(p2)
+    p02_1 = (p0.intersection(p2)).intersection(p1)
+    # The area of the intersection should be independent of the order of the
+    # intersections.
+    assert_allclose(p01_2.area(), p02_1.area(), rtol=0, atol=1e-10)
+    # 3.925526452880896 is exact result for cones. When discretized,
+    # using a finite number of steps/edges, the area is slightly different,
+    # but should be close to this value.
+    # TODO: reduce tolerance once the area calculation is more accurate.
+    assert_allclose(p02_1.area(), theor_area, rtol=0, atol=0.01)
+    assert_allclose(p01_2.area(), theor_area, rtol=0, atol=0.01)
+
+    # case 2 (theoretical area: 3.772239102140351):
+    theor_area = 3.772239102140351
+    p04_1 = (p0.intersection(p4)).intersection(p1)
+    p01_4 = (p0.intersection(p1)).intersection(p4)
+    assert_allclose(p04_1.area(), p01_4.area(), rtol=0, atol=1e-10)
+    assert_allclose(p04_1.area(), theor_area, rtol=0, atol=1e-10)
+    assert_allclose(p01_4.area(), theor_area, rtol=0, atol=1e-10)
+
+    # case 3 (theoretical area: 3.043038701225517):
+    theor_area = 3.043038701225517
+    p13_4 = (p1.intersection(p3)).intersection(p4)
+    p14_3 = (p1.intersection(p4)).intersection(p3)
+    assert_allclose(p13_4.area(), p14_3.area(), rtol=0, atol=1e-10)
+    assert_allclose(p13_4.area(), theor_area, rtol=0, atol=1e-10)
+    assert_allclose(p14_3.area(), theor_area, rtol=0, atol=1e-10)
+
+
+@pytest.mark.xfail(reason="currently there is no solution to get this to pass")
+def test_intersection_order_with_repeats_from_small_cones():
+    """
+    Intersections of several polygons with some repeats, e.g., A^B^C^C^B should
+    give the same result as A^B^C and should be independent of the order of the
+    intersections, e.g., (A^B)^C should give the same result as (A^C)^B.
+
+    Inspired from https://github.com/spacetelescope/spherical_geometry/issues/292
+    """
+    #TODO: It would be useful to check that intersection polygons have the same
+    # number of vertices and same vertex coordinates, although this can be
+    # tricky as theoretically these vertices could be partially different,
+    # e.g., some polygons could have extra vertices lying on the arc connecting
+    # two adjacent vertices that are present in both orders of intersection.
+    # These polygons would be equivalent but we currently do not a way to
+    # detect this.
+
+    cone0 = {'lat': 40.5785, 'lon': -102.4005, 'radius': 46.08093425137112}
+    cone1 = {'lat': -33.5605, 'lon': -70.5815, 'radius': 79.64909777330483}
+    cone2 = {'lat': 38.9005, 'lon': -77.0505, 'radius': 62.53797630605003}
+    cone3 = {'lat': 45.0905, 'lon': 7.6575, 'radius': 58.34122674041656}
+    cone4 = {'lat': -25.7795, 'lon': -56.4515, 'radius': 73.960984449381}
+
+    p0 = polygon.SphericalPolygon.from_cone(**cone0, degrees=True, steps=24)
+    p1 = polygon.SphericalPolygon.from_cone(**cone1, degrees=True, steps=24)
+    p2 = polygon.SphericalPolygon.from_cone(**cone2, degrees=True, steps=24)
+    p3 = polygon.SphericalPolygon.from_cone(**cone3, degrees=True, steps=24)
+    p4 = polygon.SphericalPolygon.from_cone(**cone4, degrees=True, steps=24)
+    polygons = [p0, p1, p2, p3, p4]
+
+    # case 1 (theoretical area: 1.6677035846811172):
+    theor_area = 1.6677035846811172
+    u = (1, 2, 4, 4, 2)
+    p = polygons[u[0]]
+    for i in u[1::]:
+        p = p.intersection(polygons[i])
+    area1 = p.area()
+
+    u = (1, 2, 4)  # same as above but with repeats removed
+    pr = polygons[u[0]]
+    for i in u[1::]:
+        pr = pr.intersection(polygons[i])
+    area2 = pr.area()
+
+    assert_allclose(area1, area2, rtol=0, atol=1e-10)
+    assert_allclose(area2, theor_area, rtol=0.05, atol=0)
+    assert np.vstack(list(p.points)).shape == np.vstack(list(pr.points)).shape
+
+    # case 2 (theoretical area: 0.1394454760460098):
+    theor_area = 0.1394454760460098
+    u = (0, 1, 2, 2, 3)
+    p = polygons[u[0]]
+    for i in u[1::]:
+        p = p.intersection(polygons[i])
+    area1 = p.area()
+
+    u = (0, 1, 2, 3)  # same as above but with repeats removed
+    pr = polygons[u[0]]
+    for i in u[1::]:
+        pr = pr.intersection(polygons[i])
+    area2 = pr.area()
+
+    assert_allclose(area1, area2, rtol=0, atol=1e-10)
+    assert_allclose(area2, theor_area, rtol=0.05, atol=0)
+    assert np.vstack(list(p.points)).shape == np.vstack(list(pr.points)).shape

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -456,6 +456,8 @@ def test_commutative_intersection(polygons):
     sorted_intersection_area = sorted_intersection.area()
 
     assert_allclose(unsorted_intersection_area, sorted_intersection_area)
+
+
 @pytest.mark.xfail(reason="currently there is no solution to get this to pass")
 def test_intersection_order_independent_from_large_cones():
     """

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -268,7 +268,15 @@ equals_qd(const qd *A, const qd *B)
 static NPY_INLINE int
 length_qd(const qd *A, const qd *B, qd *l)
 {
-    qd s;
+    qd s, t[3], u;
+    double norm[4];
+    int flag;
+
+    if ((A[0].x[0] == 0.0 && A[1].x[0] == 0.0 && A[2].x[0] == 0.0) ||
+        (B[0].x[0] == 0.0 && B[1].x[0] == 0.0 && B[2].x[0] == 0.0)) {
+        PyErr_SetString(PyExc_ValueError, "Null vector.");
+        return 1;
+    }
 
     /* Special case for "exactly equal" that avoids all of the calculation. */
     if (equals_qd(A, B)) {
@@ -280,13 +288,14 @@ length_qd(const qd *A, const qd *B, qd *l)
     }
 
     dot_qd(A, B, &s);
-
-    if (ISNAN_QD(s) || s.x[0] < -1.0 || s.x[0] > 1.0) {
-        PyErr_SetString(PyExc_ValueError, "Out of domain for acos");
+    if (ISNAN_QD(s)) {
+        PyErr_SetString(PyExc_ValueError, "Out of domain for atan2");
         return 1;
     }
-
-    c_qd_acos(s.x, l->x);
+    cross_qd(A, B, t);
+    dot_qd(t, t, &u);
+    flag = c_qd_sqrt(u.x, norm);
+    c_qd_atan2(norm, s.x, l->x);
     return 0;
 }
 
@@ -670,12 +679,6 @@ DOUBLE_length(char **args, const intp *dimensions, const intp *steps, void *NPY_
     load_point_qd(ip1, is1, A);
     load_point_qd(ip2, is2, B);
 
-    if (normalize_qd(A, A)) {
-        return;
-    }
-    if (normalize_qd(B, B)) {
-        return;
-    }
     if (length_qd(A, B, &s)) {
         return;
     }


### PR DESCRIPTION
This PR improves accuracy of arc length computations especially for extreme cases. It also adds unit tests based on examples from #292 and possibly #278. Updated docs in `Node.equals()`. Added helpers to write polygon to text files for debugging purposes.