### PR TITLE
add test for roundtripping polygon from lonlats and xyzs

### DIFF
--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -870,8 +870,12 @@ def test_polygon_roundtrip(lonlats):
     p_from_lonlats = polygon.SingleSphericalPolygon.from_lonlat(lonlats[:, 0], lonlats[:, 1])
     p_from_xyzs = polygon.SingleSphericalPolygon(xyzs)
 
-    np.testing.assert_allclose(np.stack(p_from_lonlats.to_lonlat(), axis=1), lonlats)
-    np.testing.assert_allclose(np.stack(p_from_xyzs.to_lonlat(), axis=1), lonlats)
+    # flip input points around to match internal representation
+    oriented_lonlats = np.flip(np.concatenate([lonlats, [lonlats[0]]], axis=0), axis=0)
+    oriented_xyzs = np.flip(np.concatenate([xyzs, [xyzs[0]]], axis=0), axis=0)
 
-    np.testing.assert_allclose(p_from_lonlats.points, xyzs)
-    np.testing.assert_allclose(p_from_xyzs.points, xyzs)
+    np.testing.assert_allclose(np.stack(p_from_lonlats.to_lonlat(), axis=1), oriented_lonlats)
+    np.testing.assert_allclose(np.stack(p_from_xyzs.to_lonlat(), axis=1), oriented_lonlats)
+
+    np.testing.assert_allclose(p_from_lonlats.points, oriented_xyzs)
+    np.testing.assert_allclose(p_from_xyzs.points, oriented_xyzs)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -870,12 +870,13 @@ def test_polygon_roundtrip(lonlats):
     p_from_lonlats = polygon.SingleSphericalPolygon.from_lonlat(lonlats[:, 0], lonlats[:, 1])
     p_from_xyzs = polygon.SingleSphericalPolygon(xyzs)
 
-    # flip input points around to match internal representation
-    oriented_lonlats = np.flip(np.concatenate([lonlats, [lonlats[0]]], axis=0), axis=0)
-    oriented_xyzs = np.flip(np.concatenate([xyzs, [xyzs[0]]], axis=0), axis=0)
+    if not p_from_lonlats.is_clockwise():
+        # flip input points around to match internal representation
+        lonlats = np.flip(np.concatenate([lonlats, [lonlats[0]]], axis=0), axis=0)
+        xyzs = np.flip(np.concatenate([xyzs, [xyzs[0]]], axis=0), axis=0)
 
-    np.testing.assert_allclose(np.stack(p_from_lonlats.to_lonlat(), axis=1), oriented_lonlats)
-    np.testing.assert_allclose(np.stack(p_from_xyzs.to_lonlat(), axis=1), oriented_lonlats)
+    np.testing.assert_allclose(np.stack(p_from_lonlats.to_lonlat(), axis=1), lonlats)
+    np.testing.assert_allclose(np.stack(p_from_xyzs.to_lonlat(), axis=1), lonlats)
 
-    np.testing.assert_allclose(p_from_lonlats.points, oriented_xyzs)
-    np.testing.assert_allclose(p_from_xyzs.points, oriented_xyzs)
+    np.testing.assert_allclose(p_from_lonlats.points, xyzs)
+    np.testing.assert_allclose(p_from_xyzs.points, xyzs)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -815,3 +815,63 @@ def test_polygon_contains_inside_point():
 
     assert p1.contains_point(p1._find_new_inside())
     assert not p1.contains_point(p1._find_new_outside())
+
+
+# TODO make this test pass
+@pytest.mark.parametrize(
+    "lonlats",
+    [
+        [(90.0, 0.0), (0.0, 45.0), (0.0, -45.0)],
+        [(90.0, 0.0), (0.0, 22.5), (0.0, -22.5)],
+        [(90.0, 0.0), (0.0, 11.25), (0.0, -11.25)],
+        [
+            (20.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 10.0),
+            (20.0, 10.0),
+        ],
+        [
+            (5.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 15.0),
+            (5.0, 15.0),
+        ],
+        [
+            (18.0, 6.0),
+            (20.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 10.0),
+            (20.0, 10.0),
+            (18.0, 7.0),
+        ],
+        [
+            (18.0, 7.0),
+            (20.0, 10.0),
+            (25.0, 10.0),
+            (25.0, 5.0),
+            (20.0, 5.0),
+            (18.0, 6.0),
+        ],
+        [
+            (18.0, 6.0),
+            (20.0, 5.0),
+            (25.0, 5.0),
+            (25.0, 10.0),
+            (20.0, 10.0),
+            (19.0, 8.0),  # concave point
+            (18.0, 7.0),
+        ],
+    ],
+)
+def test_polygon_roundtrip(lonlats):
+    lonlats = np.asanyarray(lonlats)
+    xyzs = np.stack(vector.lonlat_to_vector(lonlats[:, 0], lonlats[:, 1]), axis=1)
+
+    p_from_lonlats = polygon.SingleSphericalPolygon.from_lonlat(lonlats[:, 0], lonlats[:, 1])
+    p_from_xyzs = polygon.SingleSphericalPolygon(xyzs)
+
+    np.testing.assert_allclose(np.stack(p_from_lonlats.to_lonlat(), axis=1), lonlats)
+    np.testing.assert_allclose(np.stack(p_from_xyzs.to_lonlat(), axis=1), lonlats)
+
+    np.testing.assert_allclose(p_from_lonlats.points, xyzs)
+    np.testing.assert_allclose(p_from_xyzs.points, xyzs)


### PR DESCRIPTION
yet another bug, it seems. 

to reproduce, do:
```shell
pytest -k roundtrip -v
```

The input `lonlats` array is:
```
[[18.,  7.],
 [20., 10.],
 [25., 10.],
 [25.,  5.],
 [20.,  5.],
 [18.,  6.]]
```
```
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0
E       
E       Mismatched elements: 8 / 14 (57.1%)
E       Max absolute difference among violations: 5.
E       Max relative difference among violations: 1.
E        ACTUAL: array([[18.,  7.],
E              [20., 10.],
E              [25., 10.],...
E        DESIRED: array([[18.,  7.],
E              [18.,  6.],
E              [20.,  5.],...

spherical_geometry/tests/test_basic.py:913: AssertionError
```