### PR TITLE
Add details to _sanity_check error messages

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -7,7 +7,6 @@ This contains the code that does the actual unioning of regions.
 
 # STDLIB
 import inspect
-import sys
 import weakref
 
 # THIRD-PARTY

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -6,6 +6,7 @@ This contains the code that does the actual unioning of regions.
 # TODO: Weak references for memory management problems?
 
 # STDLIB
+import inspect
 import sys
 import weakref
 
@@ -37,8 +38,15 @@ def edge_order(edge):
 
 
 def _malformed_polygon_error(msg):
-    line = sys._getframe(1).f_lineno
-    raise MalformedPolygonError(f"{msg} in module: \"{__name__}\" at line: {line}")
+    frame = inspect.currentframe()
+    if frame is not None and frame.f_back is not None:
+        line = frame.f_back.f_lineno
+    else:
+        line = "unknown"
+
+    raise MalformedPolygonError(
+        f"{msg} in module: \"{__name__}\" at line: {line}"
+    )
 
 
 class Graph:

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -39,10 +39,13 @@ def edge_order(edge):
 
 def _malformed_polygon_error(msg):
     frame = inspect.currentframe()
-    if frame is not None and frame.f_back is not None:
-        line = frame.f_back.f_lineno
-    else:
-        line = "unknown"
+    try:
+        if frame is not None and frame.f_back is not None:
+            line = frame.f_back.f_lineno
+        else:
+            line = "unknown"
+    finally:
+        del frame
 
     raise MalformedPolygonError(
         f"{msg} in module: \"{__name__}\" at line: {line}"

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -6,6 +6,7 @@ This contains the code that does the actual unioning of regions.
 # TODO: Weak references for memory management problems?
 
 # STDLIB
+import sys
 import weakref
 
 # THIRD-PARTY
@@ -33,6 +34,11 @@ def node_order(node):
 
 def edge_order(edge):
     return node_order(edge._nodes[0]) + node_order(edge._nodes[1])
+
+
+def _malformed_polygon_error(msg):
+    line = sys._getframe(1).f_lineno
+    raise MalformedPolygonError(f"{msg} in module: \"{__name__}\" at line: {line}")
 
 
 class Graph:
@@ -373,7 +379,7 @@ class Graph:
         for edge in self._edges:
             for node in edge._nodes:
                 if edge not in node._edges or node not in self._nodes:
-                    raise MalformedPolygonError(msg)
+                    _malformed_polygon_error(msg)
             edge_repr = [tuple(x._point) for x in edge._nodes]
             edge_repr.sort()
             edge_repr = tuple(edge_repr)
@@ -383,14 +389,15 @@ class Graph:
         for node in self._nodes:
             if node_is_2:
                 if len(node._edges) % 2 != 0:
-                    raise MalformedPolygonError(msg)
+                    _malformed_polygon_error(msg)
+
             else:
                 if not len(node._edges) >= 2:
-                    raise MalformedPolygonError(msg)
+                    _malformed_polygon_error(msg)
 
             for edge in node._edges:
                 if node not in edge._nodes or edge not in self._edges:
-                    raise MalformedPolygonError(msg)
+                    _malformed_polygon_error(msg)
 
     def union(self):
         """


### PR DESCRIPTION
This PR adds details to `MalformedPolygonError` so that it can be easier to debug. 