### PR TITLE
Improve arc intersection and area computations. Fix graph

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,15 @@ Release Notes
 - Aded two unit tests based on #292 (and possibly #278)that are marked
   with ``xfail`` for now. [#322]
 
+- Implemented a more robust polygon area computation using Oosterom-Strackee
+  which replaces previous computation that used Girard's theorem. [#333]
+
+- Implemented a more robust algorithm for detecting nearly identical polygons. [#333]
+
+- Improved computation of arc-to-arc intersections in the ``great_circle_arc``
+  module. This fixed the two new added tests previously marked as xfailing
+  (in #322). [#333]
+
 
 1.4.0 (2026-03-11)
 ==================

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This contains the code that does the actual unioning of regions.
@@ -7,18 +6,20 @@ This contains the code that does the actual unioning of regions.
 
 # STDLIB
 import inspect
+import math
 import weakref
 
 # THIRD-PARTY
 import numpy as np
 
-from . import math_util
-
 # LOCAL
 from spherical_geometry import great_circle_arc as gca
 from spherical_geometry import vector
-from spherical_geometry.polygon import (SingleSphericalPolygon, SphericalPolygon,
-                                        MalformedPolygonError)
+from spherical_geometry.polygon import (
+    MalformedPolygonError,
+    SingleSphericalPolygon,
+    SphericalPolygon,
+)
 
 __all__ = ['Graph']
 
@@ -69,7 +70,7 @@ class Graph:
         A `~Graph.Node` represents a single point, connected by an arbitrary
         number of `~Graph.Edge` objects to other `~Graph.Node` objects.
         """
-        def __init__(self, point, source_polygons=[]):
+        def __init__(self, point, source_polygons=None):
             """
             Parameters
             ----------
@@ -79,7 +80,7 @@ class Graph:
                 The polygon(s) this node came from.  Used for bookkeeping.
             """
             self._point = np.asanyarray(point)
-            self._source_polygons = set(source_polygons)
+            self._source_polygons = set() if source_polygons is None else set(source_polygons)
             self._edges = weakref.WeakSet()
 
         def __repr__(self):
@@ -101,7 +102,6 @@ class Graph:
                 empirical test cases. Relative threshold based on
                 the actual sizes of polygons is not implemented.
             """
-            # return np.array_equal(self._point, other._point)
             return np.linalg.norm(self._point - other._point) < thresh
             # Possibly more accurate but much slower.
             # TODO: do more testing once the main stability issues are dealt with.
@@ -112,7 +112,7 @@ class Graph:
         An `~Graph.Edge` represents a connection between exactly two
         `~Graph.Node` objects.  This `~Graph.Edge` class has no direction.
         """
-        def __init__(self, A, B, source_polygons=[]):
+        def __init__(self, A, B, source_polygons=None):
             """
             Parameters
             ----------
@@ -124,7 +124,7 @@ class Graph:
             self._nodes = [A, B]
             for node in self._nodes:
                 node._edges.add(self)
-            self._source_polygons = set(source_polygons)
+            self._source_polygons = set() if source_polygons is None else set(source_polygons)
 
         def __repr__(self):
             nodes = self._nodes
@@ -226,7 +226,7 @@ class Graph:
         # Close the polygon
         self._add_edge(nodeA, start_node, [polygon])
 
-    def _add_node(self, point, source_polygons=[]):
+    def _add_node(self, point, source_polygons=None):
         """
         Add a node to the graph.  It will be disconnected until used
         in a call to `_add_edge`.
@@ -268,9 +268,12 @@ class Graph:
             indices = np.nonzero(diff)[0]
             if len(indices):
                 node = nodes[indices[0]]
-                node._source_polygons.update(source_polygons)
+                if source_polygons is not None:
+                    node._source_polygons.update(source_polygons)
                 return node
 
+        if source_polygons is not None:
+            source_polygons = set(source_polygons)
         new_node = self.Node(point, source_polygons)
         self._nodes.add(new_node)
         return new_node
@@ -295,7 +298,7 @@ class Graph:
         if node in self._nodes:
             self._nodes.remove(node)
 
-    def _add_edge(self, A, B, source_polygons=[]):
+    def _add_edge(self, A, B, source_polygons=None):
         """
         Add an edge between two nodes.
 
@@ -327,7 +330,12 @@ class Graph:
                  B is edge._nodes[1]) or
                 (A is edge._nodes[1] and
                  B is edge._nodes[0])):
-                edge._source_polygons.update(source_polygons)
+                # Q: is it possible for an edge to be between the same two
+                # nodes but not be the same edge?
+                # Q: what happens when A and B are the same node?
+                # Should we allow self-pointing edges?
+                if source_polygons is not None:
+                    edge._source_polygons.update(source_polygons)
                 return edge
 
         new_edge = self.Edge(A, B, source_polygons)
@@ -384,6 +392,9 @@ class Graph:
         A, B = edge._nodes
         edgeA = self._add_edge(A, node, edge._source_polygons)
         edgeB = self._add_edge(node, B, edge._source_polygons)
+        # Q: When can edge be edgeA or edgeB? is it when node is either A or B?
+        # If so, wouldn't it be better not to add edgeA or edgeB and just keep edge?
+        # If edge is edgeA, then edgeB must be degenerate.
         if edge not in (edgeA, edgeB):
             self._remove_edge(edge)
         return [edgeA, edgeB]
@@ -583,6 +594,8 @@ class Graph:
                         if edge not in edges]
 
                     for end_point in AB._nodes:
+                        # Q: doesn't 'node' already have its own source polygons?
+                        # Why do we need to update it with the end point's source polygons?
                         node._source_polygons.update(
                             end_point._source_polygons)
                     edges = edges + new_edges
@@ -715,6 +728,10 @@ class Graph:
             for polygon in polygons:
                 if polygon in edge._source_polygons:
                     edge._count += 1
+
+                # TODO: This seems unreliable, especially the midpoint check:
+                #       it may fail for concave polygons and also for large
+                #       polygons spanning a significant portion of the sphere.
                 elif ((polygon in A._source_polygons or
                        polygon.contains_point(A._point)) and
                       (polygon in B._source_polygons or
@@ -757,6 +774,10 @@ class Graph:
         for edge in self._edges:
             nedges_a = len(edge._nodes[0]._edges)
             nedges_b = len(edge._nodes[1]._edges)
+
+            # Q: Why 3? Why not >= 2 ? When can two nodes be connected by more
+            # than one edge? I thought this code no longer uses cut lines,
+            # so how can this happen or when 2 lines are allowed?
             if (nedges_a % 2 == 1 and nedges_a >= 3 and
                     nedges_b % 2 == 1 and nedges_b >= 3):
                 removals.append(edge)
@@ -797,15 +818,18 @@ class Graph:
                     return False
         return True
 
-    def _trace_polygons(self):
+    def _trace_polygons_orig(self):
         """
         Given a graph that has had cutlines removed and all
         intersections found, traces it to find a list of
-        disjoint polygons
+        disjoint polygons.
         """
+        # TODO: This function should be removed in a future release. For now
+        # we keep it around for testing purposes, but it is not used
+        # in the main code path.
 
         def edge_normal(edge, last_edge):
-            # THe normal vector to the plane defining the arc
+            # The normal vector to the plane defining the arc
             normal = gca._cross_and_normalize(edge._nodes[0]._point,
                                               edge._nodes[1]._point)
             if last_edge is not None:
@@ -851,7 +875,8 @@ class Graph:
             schwartz = zip(dot, candidates)
             schwartz = sorted(schwartz, key=lambda x: x[0])
 
-            middle = len(candidates) // 2
+            middle = len(candidates) // 2  # NOTE: this was "heuristic" part
+                                           # in the original code.
             return schwartz[middle][1]
 
         polygons = []
@@ -883,6 +908,136 @@ class Graph:
             polygons.append(polygon)
 
         return polygons
+
+    def _trace_polygons(self):
+        """
+        Given a graph that has had cutlines removed and all
+        intersections found, traces it to find a list of
+        disjoint polygons.
+
+        Assumes:
+        - graph represents simple (non-self-intersecting) spherical polygons
+        - edges are great-circle arcs between unit 3D points
+        - polygons are not larger than a hemisphere (recommended)
+        """
+        EPS = 1e-12          # for projection normalization
+        ANG_EPS = 1e-8       # skip near-zero angles to avoid backtracking
+
+        def edge_dir(node, edge):
+            """
+            Direction of edge when leaving `node`, projected to the tangent
+            plane at `node._point` and normalized.
+            """
+            p = node._point
+            q = edge.follow(node)._point  # other endpoint
+
+            # project q onto tangent plane at p
+            v = q - np.dot(q, p) * p
+            nrm = np.linalg.norm(v)
+            if nrm < EPS:
+                return v
+            return v / nrm
+
+        def signed_turn_angle(node, last_edge, next_edge):
+            """
+            Signed angle from last_edge to next_edge around the normal `node._point`.
+            Positive = left turn when looking along node._point.
+            """
+            p = node._point
+            d0 = edge_dir(node, last_edge)
+            d1 = edge_dir(node, next_edge)
+
+            # atan2( (d0 x d1)·p , d0·d1 )
+            cross = np.cross(d0, d1)
+            sin_theta = np.dot(cross, p)
+            cos_theta = np.dot(d0, d1)
+            angle = math.atan2(sin_theta, cos_theta)
+
+            # normalize to [0, 2π)
+            if angle < 0.0:
+                angle += 2.0 * math.pi
+
+            return angle
+
+        def pick_next_edge(node, last_edge):
+            """
+            Pick the next edge when arriving at `node` from `last_edge`.
+
+            Strategy:
+            - If only one unused edge, take it.
+            - Otherwise, choose the unused edge that gives the smallest
+                positive turn angle from `last_edge` around the node's normal.
+            - Skip angles < ANG_EPS to avoid backtracking or nearly-collinear edges.
+            """
+            candidates = [e for e in node._edges if not e._followed]
+
+            if not candidates:
+                raise ValueError("No more edges to follow at node")
+
+            if last_edge is None or len(candidates) == 1:
+                return candidates[0]
+
+            best_edge = None
+            best_angle = None
+
+            for e in candidates:
+                ang = signed_turn_angle(node, last_edge, e)
+
+                # Skip near-zero angles (backtracking / straight-through)
+                if ang < ANG_EPS:
+                    continue
+
+                if best_angle is None or ang < best_angle:
+                    best_angle = ang
+                    best_edge = e
+
+            # If all angles were < ANG_EPS, fall back to smallest angle
+            if best_edge is None:
+                for e in candidates:
+                    ang = signed_turn_angle(node, last_edge, e)
+                    if best_angle is None or ang < best_angle:
+                        best_angle = ang
+                        best_edge = e
+
+            return best_edge
+
+        polygons = []
+        edges = set(self._edges)  # copy
+        for edge in self._edges:
+            edge._followed = False
+
+        while edges:
+            points = []
+
+            # start from an arbitrary unused edge
+            edge = edges.pop()
+            edge._followed = True
+            start_node = node = edge._nodes[0]
+
+            points.append(node._point)
+            node = edge._nodes[1]
+            points.append(node._point)
+
+            while True:
+                if not np.array_equal(points[-1], node._point):
+                    points.append(node._point)
+
+                next_edge = pick_next_edge(node, edge)
+                next_edge._followed = True
+                edges.discard(next_edge)
+
+                edge = next_edge
+                node = edge.follow(node)
+
+                if node is start_node:
+                    points.append(node._point)
+                    break
+
+            polygon = SingleSphericalPolygon(points)
+            polygons.append(polygon)
+
+        return polygons
+
 
     def _trace(self):
         """

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 The `spherical_geometry.great_circle_arc` module contains functions for computing
@@ -8,6 +7,8 @@ Great circles are circles on the unit sphere whose center is
 coincident with the center of the sphere.  Great circle arcs are the
 section of those circles between two points on the unit sphere.
 """
+# STDLIB
+from fractions import Fraction
 
 # THIRD-PARTY
 import numpy as np
@@ -63,21 +64,38 @@ else:
 
 
 if HAS_C_UFUNCS:
-    def _cross_and_normalize(A, B):
+    def _cross_and_normalize(A, B, eps=1e-31):
         with np.errstate(invalid='ignore'):
+            # TODO: Figure out how to pass eps to C-ufunc
             return math_util.cross_and_norm(A, B)
 else:
-    def _cross_and_normalize(A, B):
-        T = _fast_cross(A, B)
-        # Normalization
-        l = np.sqrt(np.sum(T ** 2, axis=-1))
-        l = two_d(l)
-        # Might get some divide-by-zeros
-        with np.errstate(invalid='ignore'):
-            TN = T / l
-        # ... but set to zero, or we miss real NaNs elsewhere
-        TN = np.nan_to_num(TN)
-        return TN
+    def _cross_and_normalize(a, b, eps=1e-15):
+        a = np.asarray(a, dtype=float)
+        b = np.asarray(b, dtype=float)
+
+        # Cross product, shape (..., 3)
+        x = _fast_cross(a, b)
+
+        # Norm, shape (...)
+        n = np.linalg.norm(x, axis=-1)
+
+        # Scalar case
+        if np.isscalar(n):
+            if n < eps:
+                return np.full_like(x, np.nan, dtype=float)
+            return x / n
+
+        # Array case
+        mask_small = n <= eps  # shape (...)
+        denom = n.copy()
+        denom[mask_small] = np.nan
+
+        # Broadcast denom to (..., 3)
+        denom = denom[..., None]
+
+        with np.errstate(invalid="ignore", divide="ignore"):
+            out = x / denom
+        return out
 
 
 if HAS_C_UFUNCS:
@@ -87,7 +105,7 @@ else:
         return inner1d(C, _fast_cross(A, B))
 
 
-def intersection(A, B, C, D):
+def intersection_old(A, B, C, D):
     r"""
     Returns the point of intersection between two great circle arcs.
     The arcs are defined between the points *AB* and *CD*.  Either *A*
@@ -141,6 +159,8 @@ def intersection(A, B, C, D):
         by Roger Stafford.
 
     http://www.mathworks.com/matlabcentral/newsreader/view_thread/276271
+
+    Also see: http://www.boeing-727.com/Data/fly%20odds/distance.html
     """
     if HAS_C_UFUNCS:
         return math_util.intersection(A, B, C, D)
@@ -170,6 +190,9 @@ def intersection(A, B, C, D):
         s = two_d(s)
 
     cross = np.where(s == -4, -T, np.where(s == 4, T, np.nan))
+
+    # Q: Why do we check for strict equality below? Should we check for
+    # closeness instead? What about rounding errors?
 
     # If they share a common point, it's not an intersection.  This
     # gets around some rounding-error/numerical problems with the
@@ -280,6 +303,18 @@ def intersects_point(A, B, C):
     intersects : bool or array of bool
         If the point is on the line, returns `True`.
     """
+    # Q: How do we know how to get from A to B? Clockwise or counterclockwise?
+    # That is, do we always consider only minor arcs between two nodes?
+    #
+    # Depending on the direction, we might get different results. For example,
+    # if A is Atlanta and B is Los Angeles, do we travel from A to B moving
+    # westward or eastward?
+    #
+    # Also, if A and B are antipodes, then any point C would be along the great
+    # circle arc between A and B, but we don't want to return True for all
+    # points. So we need to determine the direction from A to B, and then check
+    # if C is along that direction.
+
     if HAS_C_UFUNCS:
         return math_util.intersects_point(A, B, C)
 
@@ -404,3 +439,143 @@ def interpolate(A, B, steps=50):
         offsets = np.sin(t * omega) / sin_omega
 
     return offsets[::-1] * A + offsets * B
+
+
+# TODO: Consider moving all this code (_det3_broadcast, robust_det_sign,
+# intersection, and possibly _exact_det3) to math_util.c.
+# _exact_det3 would require extra dependencies or, alternatively, we could
+# eliminate _exact_det3 altogether by usinbg quad precision and use small epsilon
+# to determine the sign of the determinant. Further
+
+def _det3_broadcast(a, b, c):
+    """
+    Determinant of 3x3 with rows a, b, c.
+    a, b, c: (..., 3) arrays, already broadcast to same shape.
+    Returns: (...) array of determinants.
+    """
+    return (
+        a[..., 0] * (b[..., 1] * c[..., 2] - b[..., 2] * c[..., 1]) -
+        a[..., 1] * (b[..., 0] * c[..., 2] - b[..., 2] * c[..., 0]) +
+        a[..., 2] * (b[..., 0] * c[..., 1] - b[..., 1] * c[..., 0])
+    )
+
+
+def _exact_det3(a, b, c):
+    """
+    Exact 3x3 determinant using Fractions for single 3-vectors.
+    a, b, c: shape (3,) arrays, assumed finite and non-NaN.
+    """
+    fa = [Fraction(x) for x in a]
+    fb = [Fraction(x) for x in b]
+    fc = [Fraction(x) for x in c]
+
+    return (
+        fa[0] * (fb[1] * fc[2] - fb[2] * fc[1]) -
+        fa[1] * (fb[0] * fc[2] - fb[2] * fc[0]) +
+        fa[2] * (fb[0] * fc[1] - fb[1] * fc[0])
+    )
+
+
+def robust_det_sign(a, b, c, eps=1e-15):
+    """
+    Shewchuk-style adaptive sign of det([a; b; c]) with broadcasting.
+
+    a, b, c: (..., 3) arrays (any broadcastable combination).
+    Returns: int array of shape (...) with values in {-1, 0, +1}.
+    """
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    c = np.asarray(c, dtype=float)
+
+    # Broadcast all three to a common shape (..., 3)
+    a, b, c = np.broadcast_arrays(a, b, c)
+
+    det = _det3_broadcast(a, b, c)
+    sign = np.zeros_like(det, dtype=int)
+
+    # fast path: |det| > eps → sign from float
+    mask_fast_pos = det > eps
+    mask_fast_neg = det < -eps
+    sign[mask_fast_pos] = 1
+    sign[mask_fast_neg] = -1
+
+    # slow path: |det| <= eps → exact Fraction per element
+    mask_slow = ~(mask_fast_pos | mask_fast_neg)
+
+    if np.any(mask_slow):
+        it = np.nditer(mask_slow, flags=['multi_index'])
+        while not it.finished:
+            if it[0]:
+                idx = it.multi_index
+                a_i = a[idx]  # shape (3,)
+                b_i = b[idx]
+                c_i = c[idx]
+
+                # If any NaN/inf is present, we cannot do exact arithmetic;
+                # treat as indeterminate sign → 0.
+                if (np.isnan(a_i).any() or np.isnan(b_i).any() or np.isnan(c_i).any() or
+                    np.isinf(a_i).any() or np.isinf(b_i).any() or np.isinf(c_i).any()):
+                    sign[idx] = 0
+                else:
+                    det_exact = _exact_det3(a_i, b_i, c_i)
+                    if det_exact > 0:
+                        sign[idx] = 1
+                    elif det_exact < 0:
+                        sign[idx] = -1
+                    else:
+                        sign[idx] = 0
+            it.iternext()
+
+    return sign
+
+
+def intersection(A, B, C, D, eps=1e-13):
+    r"""
+    Returns the point of intersection between two great circle arcs.
+    The arcs are defined between the points *AB* and *CD*.  Either *A*
+    and *B* or *C* and *D* may be arrays of points, but not both.
+    """
+
+    A = np.asanyarray(A, dtype=float)
+    B = np.asanyarray(B, dtype=float)
+    C = np.asanyarray(C, dtype=float)
+    D = np.asanyarray(D, dtype=float)
+
+    A, B = np.broadcast_arrays(A, B)
+    C, D = np.broadcast_arrays(C, D)
+
+    ABX = _fast_cross(A, B)
+    CDX = _fast_cross(C, D)
+    T = _cross_and_normalize(ABX, CDX, eps=eps)
+    T_ndim = T.ndim
+
+    if T_ndim > 1:
+        s = np.zeros(T.shape[0], dtype=int)
+    else:
+        s = np.zeros(1, dtype=int)
+
+    # ((A x B) x A) . T  == det([A x B; A; T])
+    s += robust_det_sign(ABX, A, T, eps=eps)
+    # (B x (A x B)) · T  == det([B; A x B; T])
+    s += robust_det_sign(B, ABX, T, eps=eps)
+    # ((C x D) x C) · T  == det([C x D; C; T])
+    s += robust_det_sign(CDX, C, T, eps=eps)
+    # (D x (C x D)) · T  == det([D; C x D; T])
+    s += robust_det_sign(D, CDX, T, eps=eps)
+
+    if T_ndim > 1:
+        s_col = two_d(s)
+    else:
+        s_col = s
+
+    cross = np.where(s_col == -4, -T,
+                     np.where(s_col == 4, T, np.nan))
+
+    equals = (np.all(A == C, axis=-1) |
+              np.all(A == D, axis=-1) |
+              np.all(B == C, axis=-1) |
+              np.all(B == D, axis=-1))
+
+    equals = two_d(equals)
+
+    return np.where(equals, np.nan, cross)

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 The `spherical_geometry.polygon` module defines the `SphericalPolygon` class for
@@ -6,6 +5,7 @@ managing polygons on the unit sphere.
 """
 
 # STDLIB
+import itertools
 from copy import deepcopy
 
 # THIRD-PARTY
@@ -14,15 +14,160 @@ import numpy as np
 # LOCAL
 from spherical_geometry import great_circle_arc, vector
 
-__all__ = ['SingleSphericalPolygon', 'SphericalPolygon',
-           'MalformedPolygonError']
+try:
+    from spherical_geometry import math_util
+    qd_single_polygon_area = math_util.single_polygon_area
+    HAS_C_UFUNCS = True
+except ImportError:
+    HAS_C_UFUNCS = False
+
+__all__ = [
+    'MalformedPolygonError',
+    'SingleSphericalPolygon',
+    'SphericalPolygon',
+]
 
 
 class MalformedPolygonError(Exception):
     pass
 
 
-class SingleSphericalPolygon(object):
+def _solid_angle_triangle(a, b, c):
+    """
+    Oosterom-Strackee solid angle of spherical triangle (a,b,c).
+    All inputs must be unit vectors.
+    """
+    det = np.dot(a, np.cross(b, c))
+    denom = 1 + np.dot(a, b) + np.dot(b, c) + np.dot(c, a)
+    return 2 * np.arctan2(det, denom)
+
+
+def single_polygon_area(polygon):
+    """
+    Robust spherical polygon area for convex, concave, or > hemisphere polygons.
+    vertices: list of 3D vectors (not necessarily normalized)
+    """
+    if polygon._degenerate:
+        return 0.0
+
+    if len(polygon._points) < 4:
+        return 0.0
+
+    verts = polygon._points
+
+    if HAS_C_UFUNCS:
+        return qd_single_polygon_area(verts, polygon._inside)
+
+    else:
+        # Normalize vertices for Oosterom-Strackee (vertices should have
+        # been normalized at construction, but we do it here to be safe)
+        verts = np.array([v / np.linalg.norm(v) for v in verts])
+
+        # Detect closed polygon and drop duplicate last vertex if present
+        closed = np.linalg.norm(verts[0] - verts[-1]) < 1e-12
+        n = len(verts) - 1 if closed else len(verts)
+        if n < 3:
+            return 0.0
+
+        # Fan triangulation around vertex 0
+        a = verts[0]
+        signed_area = 0.0
+        for i in range(1, n - 1):
+            signed_area += _solid_angle_triangle(a, verts[i], verts[i + 1])
+
+    # TODO: revisit this logic for determining small vs big cap. The entire
+    # code and area sign convention should be made consistent with the
+    # "inside" point and convention for the orientation of the polygon.
+    # (and maybe we don't want to store "inside" at all, but instead just look
+    # at the orientation of the polygon and compute the inside point on demand)
+    # This code here makes unit tests to pass but it is not clear that it
+    # is correct thing to do in general.
+
+    # Base small‑cap area: always positive
+    small_area = abs(signed_area)
+
+    # If no inside vector: we only know the small cap
+    if polygon._inside is None:
+        return small_area
+
+    # With inside: decide small vs big cap
+    inside = polygon._inside / np.linalg.norm(polygon._inside)
+
+    # Use centroid direction as polygon "interior" normal
+    centroid = np.sum(verts[:n], axis=0)
+    if np.linalg.norm(centroid) < 1.0e-28:
+        # Degenerate orientation: fall back to small cap
+        return small_area
+    centroid /= np.linalg.norm(centroid)
+
+    same_side = np.dot(inside, centroid) > 0
+
+    if same_side:
+        # Inside matches centroid - return small cap
+        return small_area
+    else:
+        # Inside opposite centroid - return big complement
+        return 4.0 * np.pi - small_area
+
+
+def _canonical_ring(pts, atol=1e-12):
+    """
+    Numerically stable canonical ordering of a spherical polygon ring.
+    Rotation- and orientation-invariant.
+    """
+    # NOTE: This function can change orientation of points. For polygons
+    # limited to a semisphere (the ones we support for now) this is not an issue.
+    # If orientation is important at a later point, either the caller should
+    # check the orientation and reverse if needed, or this function could
+    # return orientation in addition to the ring.
+    pts = np.asarray(pts)
+    if pts.ndim != 2 or pts.shape[1] != 3:
+        raise ValueError("Input must be a 2D array with shape (N, 3)")
+    if pts.shape[0] < 3:
+        return pts  # Not enough points to form a polygon, return as is
+    if np.allclose(pts[0], pts[-1], rtol=0, atol=10 * np.finfo(pts.dtype).eps):
+        pts = pts[:-1]  # Remove duplicate last point if polygon is closed
+
+    # Compute a stable key for each point:
+    # round coordinates to a tolerance so tiny noise does not reorder points
+    rounded = np.round(pts / atol).astype(np.int64)
+
+    # Find lexicographically smallest rounded row
+    min_idx = np.lexsort(rounded.T[::-1])[0]
+
+    # Rotate
+    rot = np.roll(pts, -min_idx, axis=0)
+
+    # Reverse orientation
+    rev = np.vstack((rot[0], rot[:0:-1]))
+
+    # Compare full sequences using rounded keys
+    rounded_rot = np.round(rot / atol).astype(np.int64)
+    rounded_rev = np.round(rev / atol).astype(np.int64)
+
+    if tuple(map(tuple, rounded_rev)) < tuple(map(tuple, rounded_rot)):
+        return rev
+
+    return rot
+
+
+def _angular_equal(a, b, atol=1e-8):
+    """
+    Compare two Nx3 rings for equality up to circular shift using angular tolerance.
+    tol is in absolute coordinate units (approx radians on unit sphere).
+    """
+    a = np.asarray(a)
+    b = np.asarray(b)
+    if a.shape != b.shape:
+        return False
+    # canonicalize both
+    ca = _canonical_ring(a)
+    cb = _canonical_ring(b)
+    # direct coordinate comparison with atol (works because canonicalized)
+    return np.allclose(ca, cb, rtol=0, atol=atol)
+
+
+class SingleSphericalPolygon:
     r"""
     Polygons are represented by both a set of points (in Cartesian
     (*x*, *y*, *z*) normalized on the unit sphere), and an inside
@@ -58,15 +203,33 @@ class SingleSphericalPolygon(object):
         else:
             self._degenerate = False
 
+        # TODO: revisit this requirement that the polygon be explicitly closed.
+        # This has to be done after reviewing everything as in other pars of
+        # the code last vex is removed from computations.
         if not np.array_equal(points[0], points[-1]):
             points = list(points[:])
             points.append(points[0])
 
         self._points = points = np.asanyarray(points)
 
+        # Check that all vertices are not close to null vectors, which would
+        # cause problems with normalization and area calculations.
+        norms = np.linalg.norm(points, axis=1)
+
+        if np.any(norms < 1e-10):
+            self._degenerate = True
+            self._inside = None
+            return
+
         if len(points) < 4:
             self._inside = None
             raise ValueError("Polygon made of too few points")
+
+        # normalize the points to ensure they are on the unit sphere.
+        # TODO: when quad arithmetic is available, we should use probably store
+        # vertices using quad representations and normalize once using quad
+        # accuracy. This should improve performance somewhat.
+        # self._points = points = points / norms[:, np.newaxis]
 
         orient, new_inside = self._get_orient(compute_inside=True)
         if orient is None:
@@ -94,8 +257,7 @@ class SingleSphericalPolygon(object):
         return 1
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__,
-                               self.points, self.inside)
+        return f'{self.__class__.__name__}({self.points!r}, {self.inside!r})'
 
     def __iter__(self):
         """
@@ -708,6 +870,7 @@ class SingleSphericalPolygon(object):
         counter-clockwise. Take the absolute value if that is not desired.
         Area of degenerate polygons is defined to be zero.
         """
+        return single_polygon_area(self)
         if self._degenerate:
             return 0.0
 
@@ -830,7 +993,7 @@ class SingleSphericalPolygon(object):
             del plot_args['alpha']
 
         alpha = 1.0
-        for A, B in zip(points[0:-1], points[1:]):
+        for A, B in itertools.pairwise(points):
             length = np.rad2deg(great_circle_arc.length(A, B))
             if not np.isfinite(length):
                 length = 2
@@ -858,8 +1021,9 @@ class SingleSphericalPolygon(object):
             f.write("# Inside Point (x, y, z):\n")
             f.write(f"{self._inside[0]:.15g}, {self._inside[1]:.15g}, {self._inside[2]:.15g}\n")
             f.write("# Vertices (x, y, z):\n")
-            for point in self._points:
-                f.write(f"{point[0]:.15g}, {point[1]:.15g}, {point[2]:.15g}\n")
+            f.writelines(
+                f"{point[0]:.15g}, {point[1]:.15g}, {point[2]:.15g}\n" for point in self._points
+            )
 
 
 class SphericalPolygon(SingleSphericalPolygon):
@@ -909,7 +1073,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         p = SingleSphericalPolygon(init, inside)
         if p._degenerate:
             self._degenerate = True
-            self._polygons = tuple()
+            self._polygons = ()
             return
         else:
             self._degenerate = False
@@ -924,7 +1088,7 @@ class SphericalPolygon(SingleSphericalPolygon):
             polygons.extend(g.disjoint_polygons())
         if not polygons:
             self._degenerate = True
-            self._polygons = tuple()
+            self._polygons = ()
         else:
             self._polygons = polygons
 
@@ -949,7 +1113,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         """
         for polygon in self._polygons:
             for subpolygon in polygon:
-                yield subpolygon
+                yield from subpolygon
 
     @property
     def degenerate(self):
@@ -1362,18 +1526,19 @@ class SphericalPolygon(SingleSphericalPolygon):
         # Remove the next block once the bug is fixed.
         # See https://github.com/spacetelescope/spherical_geometry/issues/232
         #
-        # This woraround will result in two poligons treated as the same
+        # This workaround will result in two poligons treated as the same
         # polygon if their vertices (x, y, z on a unit sphere) differ by 5e-9.
         # This is equivalent to polygon vertices being separated by less than
         # 0.0015 arcsec on the sky or by less than 2mm on Earth (at average
         # Earth radius).
-        accepted_polygon_points = [np.sort(list(valid_polygons[0].points)[0], axis=0)]
+
+        accepted_polygon_points = [next(iter(valid_polygons[0].points))]
         filtered_polygons = [valid_polygons[0]]
+
         for p in valid_polygons[1:]:
-            pts = np.sort(list(p.points)[0], axis=0)
+            pts = next(iter(p.points))
             for pts2 in accepted_polygon_points:
-                if (pts.size == pts2.size and
-                        np.allclose(pts, pts2, rtol=0, atol=5e-9)):
+                if _angular_equal(pts, pts2, atol=5.0e-9):
                     break
             else:
                 filtered_polygons.append(p)
@@ -1382,17 +1547,63 @@ class SphericalPolygon(SingleSphericalPolygon):
 
         from . import graph
 
+        clusters = []          # list of lists of polygons
+        cluster_rings = []     # canonical ring for each cluster
+
+        atol = 5.0e-9
+
+        for poly in filtered_polygons:
+            ring = np.asarray(getattr(poly, "_points", next(iter(poly.points))))
+            can = _canonical_ring(ring)
+
+            # find cluster with matching ring
+            for i, r in enumerate(cluster_rings):
+                if _angular_equal(can, r, atol=atol):
+                    clusters[i].append(poly)
+                    break
+            else:
+                # new cluster
+                clusters.append([poly])
+                cluster_rings.append(can)
+
+        # pick ONE representative per cluster
+        accepted_polys = []
+        for polys in clusters:
+            # choose representative polygon with the largest area:
+            try:
+                rep = max(polys, key=lambda p: p.area())
+            except ValueError:
+                continue
+            accepted_polys.append(rep)
+
+        # Flatten into SingleSphericalPolygon list using _points (Nx3)
+        # to avoid iterator shape issues
         all_polygons = []
-        for polygon in filtered_polygons:
+        for polygon in accepted_polys:
             if polygon._degenerate:
                 continue
             for p in polygon:
-                if p._degenerate:
-                    continue
+                # prefer p._points if present (Nx3)
+                pts = getattr(p, "_points", None)
+                if pts is None:
+                    pts = np.asarray(list(p.points))
+                pts = np.atleast_2d(pts)
+                # we should skip polygons with too few points.
+                # for closed polygons we need at least 4 vertices.
+                # However, for now initializer ensures polygons have 4 or more
+                # vertices.
+                # if pts.shape[0] < 3:
+                #     continue
                 all_polygons.append(p)
 
+        # Build graph and union
         g = graph.Graph(all_polygons)
-        return g.union()
+        res = g.union()
+
+        # Normalize return type: Graph.union() returns a SingleSphericalPolygon
+        if isinstance(res, SingleSphericalPolygon):
+            return SphericalPolygon((res,), inside=res.inside)
+        return res
 
     def intersection(self, other):
         """
@@ -1416,9 +1627,7 @@ class SphericalPolygon(SingleSphericalPolygon):
         :mod:`~spherical_geometry.graph` module.
         """
 
-        if self.area() == 0.0:
-            return SphericalPolygon([])
-        elif other.area() == 0.0:
+        if self.area() == 0.0 or other.area() == 0.0:
             return SphericalPolygon([])
 
         all_polygons = []

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -628,7 +628,7 @@ def test_fast_area():
 
     apoly = polygon.SphericalPolygon(a)
     bpoly = polygon.SphericalPolygon(b)
-    cpoly = polygon.SphericalPolygon(c, inside=c_inside)
+    cpoly = polygon.SphericalPolygon(c[:-1, :], inside=c_inside)
 
     aarea = apoly.area()
     barea = bpoly.area()

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -434,6 +434,9 @@ def test_complement_regression():
 )
 def test_commutative_intersection(polygons):
     """https://github.com/spacetelescope/spherical_geometry/issues/292"""
+    # NOTE: my (mcara) suspicion is that this is caused by either interior point
+    # calculation or the graph tracing algorithm itself (or both), when
+    # polygons span more than a hemisphere.
 
     # pair polygons with their areas for later sorting
     polygons = [(polygon, polygon.area()) for polygon in polygons]
@@ -476,6 +479,10 @@ def test_intersection_order_independent_from_large_cones():
     # two adjacent vertices that are present in both orders of intersection.
     # These polygons would be equivalent but we currently do not a way to
     # detect this.
+
+    # NOTE: my (mcara) suspicion is that this is caused by either interior point
+    # calculation or the graph tracing algorithm itself (or both), when
+    # polygons span more than a hemisphere.
 
     cone0 = {'lat': 40.5785, 'lon': -122.4005, 'radius': 126.08093425137112}
     cone1 = {'lat': -33.5605, 'lon': -70.5815, 'radius': 90.64909777330483}
@@ -520,7 +527,6 @@ def test_intersection_order_independent_from_large_cones():
     assert_allclose(p14_3.area(), theor_area, rtol=0, atol=1e-10)
 
 
-@pytest.mark.xfail(reason="currently there is no solution to get this to pass")
 def test_intersection_order_with_repeats_from_small_cones():
     """
     Intersections of several polygons with some repeats, e.g., A^B^C^C^B should

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -354,7 +354,8 @@ def test_almost_identical_polygons_multi_union():
         )
 
     # FIXME: https://github.com/spacetelescope/spherical_geometry/issues/245
-    area_tol = 5.8e-14  # Used to be 5.0e-14 before we started testing different archs
+    area_tol = 1.0e-7
+    ref_area = 2.6672663785041255e-8
 
     # FIXME: https://github.com/spacetelescope/spherical_geometry/issues/244
     if sys.platform == "win32":
@@ -365,4 +366,4 @@ def test_almost_identical_polygons_multi_union():
     p = polygon.SphericalPolygon.multi_union(polygons)
 
     assert np.shape(list(p.points)[0]) in p_shapes
-    assert abs(p.area() - 2.6672666e-8) < area_tol
+    assert abs(p.area() - ref_area) <= area_tol * ref_area

--- a/spherical_geometry/vector.py
+++ b/spherical_geometry/vector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 The `spherical_geometry.vector` module contains the basic operations for handling
@@ -14,9 +13,15 @@ try:
 except ImportError:
     HAS_C_UFUNCS = False
 
-__all__ = ['two_d', 'lonlat_to_vector', 'vector_to_lonlat',
-           'normalize_vector', 'radec_to_vector', 'vector_to_radec',
-           'rotate_around']
+__all__ = [
+    "lonlat_to_vector",
+    "normalize_vector",
+    "radec_to_vector",
+    "rotate_around",
+    "two_d",
+    "vector_to_lonlat",
+    "vector_to_radec",
+]
 
 
 def two_d(vec):
@@ -189,14 +194,19 @@ def rotate_around(x, y, z, u, v, w, theta, degrees=True):
     if degrees:
         theta = np.deg2rad(theta)
 
+    # Consider https://doi.org/10.1016/j.mechmachtheory.2015.03.004 for an
+    # alternative formula that may be more accurate. However,
+    # current implementation below is adequate for our current needs.
+
     costheta = np.cos(theta)
     sintheta = np.sin(theta)
     icostheta = 1.0 - costheta
 
-    det = (-u*x - v*y - w*z)
-    X = (-u*det)*icostheta + x*costheta + (-w*y + v*z)*sintheta
-    Y = (-v*det)*icostheta + y*costheta + ( w*x - u*z)*sintheta
-    Z = (-w*det)*icostheta + z*costheta + (-v*x + u*y)*sintheta
+    # Rodrigues' rotation formula:
+    dotp = u * x + v * y + w * z
+    X = x * costheta + (v * z - w * y) * sintheta + u * dotp * icostheta
+    Y = y * costheta + (-u * z + w * x) * sintheta + v * dotp * icostheta
+    Z = z * costheta + (u * y - v * x) * sintheta + w * dotp * icostheta
 
     return X, Y, Z
 

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -73,7 +73,15 @@ typedef struct {
 
 #define ISNAN_QD(q) ((q.x[0]) != (q.x[0]))
 
+double QD_ZERO[4] = {0.0, 0.0, 0.0, 0.0};
 double QD_ONE[4] = {1.0, 0.0, 0.0, 0.0};
+double QD_TWO[4] = {2.0, 0.0, 0.0, 0.0};
+
+static NPY_INLINE void
+qd_set_zero(qd *v)
+{
+    v->x[0] = v->x[1] = v->x[2] = v->x[3] = 0.0;
+}
 
 static NPY_INLINE void
 load_point(const char *in, const intp s, double *out)
@@ -83,6 +91,30 @@ load_point(const char *in, const intp s, double *out)
     out[1] = (*(double *) in);
     in += s;
     out[2] = (*(double *) in);
+}
+
+void
+load_np_vector_array_qd(PyArrayObject *points, int i, qd *a)
+{
+    int j;
+    for (j = 0; j < 3; ++j) {
+        a[j].x[0] = *(double *) PyArray_GETPTR2(points, i, j);
+        a[j].x[1] = 0.0;
+        a[j].x[2] = 0.0;
+        a[j].x[3] = 0.0;
+    }
+}
+
+void
+load_np_vector_qd(PyArrayObject *point, qd *a)
+{
+    int j;
+    for (j = 0; j < 3; ++j) {
+        a[j].x[0] = *(double *) PyArray_GETPTR1(point, j);
+        a[j].x[1] = 0.0;
+        a[j].x[2] = 0.0;
+        a[j].x[3] = 0.0;
+    }
 }
 
 static NPY_INLINE void
@@ -144,12 +176,17 @@ cross_qd(const qd *A, const qd *B, qd *C)
 }
 
 static NPY_INLINE int
-normalize_qd(const qd *A, qd *B)
+normalize_qd(const qd *A, qd *B, double eps)
 {
     size_t i;
 
     double T[4][4];
     double l[4];
+
+    if (eps < 0.0) {
+        eps = 10.0 * c_qd_epsilon();
+    }
+    eps *= eps;
 
     for (i = 0; i < 3; ++i) {
         c_qd_sqr(A[i].x, T[i]);
@@ -159,11 +196,16 @@ normalize_qd(const qd *A, qd *B)
     c_qd_add(T[3], T[2], T[3]);
 
     if (T[3][0] < -0.0) {
+        for (i = 0; i < 3; ++i) {
+            c_qd_copy_d(NPY_NAN, B[i].x);
+        }
         PyErr_SetString(PyExc_ValueError, "Domain error in sqrt");
-        return 1;
+        return 2;
     }
-    if (T[3][0] == 0.0) {
-        c_qd_copy_d(NPY_NAN, B->x);
+    if (T[3][0] <= eps) {
+        for (i = 0; i < 3; ++i) {
+            c_qd_copy_d(NPY_NAN, B[i].x);
+        }
         return 1;
     }
 
@@ -174,6 +216,28 @@ normalize_qd(const qd *A, qd *B)
     }
 
     return 0;
+}
+
+/// @brief Tests whether the vertices `A` and `B` are within a specified tolerance.
+/// @param A Pointer to the first set of vertices.
+/// @param B Pointer to the second set of vertices.
+/// @param tol Tolerance value.
+/// @return int Integer boolean-style result indicating whether the vertices are close.
+static NPY_INLINE int
+is_vertex_close(const qd *A, const qd *B, double tol)
+{
+    size_t i;
+
+    double T[3][4];
+    double s[4];
+
+    for (i = 0; i < 3; ++i) {
+        c_qd_sub(A[i].x, B[i].x, T[i]);
+        c_qd_sqr(T[i], T[i]);
+    }
+    c_qd_add(T[0], T[1], s);
+    c_qd_add(s, T[2], s);
+    return (s[0] < tol * tol) ? 1 : 0;
 }
 
 static NPY_INLINE void
@@ -270,8 +334,24 @@ length_qd(const qd *A, const qd *B, qd *l)
 {
     qd s, t[3], u;
     double norm[4];
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4189) // MSVC equivalent: local variable is initialized but not referenced
+#endif
     int flag;
-
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
     if ((A[0].x[0] == 0.0 && A[1].x[0] == 0.0 && A[2].x[0] == 0.0) ||
         (B[0].x[0] == 0.0 && B[1].x[0] == 0.0 && B[2].x[0] == 0.0)) {
         PyErr_SetString(PyExc_ValueError, "Null vector.");
@@ -313,7 +393,7 @@ intersection_qd(const qd *A, const qd *B, const qd *C, const qd *D, qd *T, doubl
         cross_qd(A, B, ABX);
         cross_qd(C, D, CDX);
         cross_qd(ABX, CDX, T);
-        if (normalize_qd(T, T)) {
+        if (normalize_qd(T, T, 0.0)) {
             *match = 0;
             return;
         }
@@ -396,7 +476,7 @@ DOUBLE_normalize(char **args, const intp *dimensions, const intp *steps, void *N
 
     load_point_qd(ip1, is1, IN);
 
-    if (normalize_qd(IN, OUT)) {
+    if (normalize_qd(IN, OUT, 0.0)) {
         return;
     }
 
@@ -478,11 +558,10 @@ DOUBLE_cross_and_norm(
     load_point_qd(ip2, is2, B);
 
     cross_qd(A, B, C);
-    if (normalize_qd(C, C)) {
-        return;
-    }
+    normalize_qd(C, C, 1e-31); // return nan if norm < 1e-31
 
     save_point_qd(C, op, is3);
+
     END_OUTER_LOOP
 
     fpu_fix_end(&old_cw);
@@ -538,6 +617,96 @@ DOUBLE_triple_product(
 static PyUFuncGenericFunction triple_product_functions[] = {DOUBLE_triple_product};
 static void *triple_product_data[] = {(void *) NULL};
 static char triple_product_signatures[] = {NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE};
+
+/*///////////////////////////////////////////////////////////////////////////
+  solid_angle_triangle
+*/
+
+char *solid_angle_triangle_signature = "(i),(i),(i)->()";
+
+/*
+ * Finds the solid angle of a spherical triangle at *B* between *A*, *B*,  and *C*.
+ */
+
+static void
+t_os_solid_angle_qd(qd *a, qd *b, qd *c, qd *angle)
+{
+    qd BCX[3];
+    qd prod;
+    qd det, dots[3];
+    double denom[4] = {1.0, 0.0, 0.0, 0.0};
+    int r;
+
+    cross_qd(b, c, BCX);
+    // check for degenerate triangle:
+    dot_qd(BCX, BCX, &prod);
+    c_qd_comp_qd_d(prod.x, 1e-56, &r);
+    if (r < 0) {
+        qd_set_zero(angle);
+        return;
+    }
+
+    dot_qd(a, BCX, &det);
+    dot_qd(a, b, &dots[0]);
+    dot_qd(b, c, &dots[1]);
+    dot_qd(c, a, &dots[2]);
+
+    for (int i = 0; i < 3; ++i) {
+        c_qd_add(denom, dots[i].x, denom);
+    }
+
+    // check for great-circle degeneracy:
+    if (fabs(denom[0]) < 1e-28 && fabs(det.x[0]) < 1e-28) {
+        qd_set_zero(angle);
+        return;
+    }
+
+    // check for near antipodal degeneracy:
+    c_qd_comp_qd_d(dots[1].x, -1.0 + 1.0e-28, &r);
+    if (r < 0) {
+        qd_set_zero(angle);
+        return;
+    }
+
+    c_qd_atan2(det.x, denom, angle->x);
+    c_qd_mul(angle->x, QD_TWO, angle->x);
+}
+
+static void
+DOUBLE_solid_angle_triangle(
+    char **args, const intp *dimensions, const intp *steps, void *NPY_UNUSED(func))
+{
+    qd A[3];
+    qd B[3];
+    qd C[3];
+
+    qd angle;
+
+    unsigned int old_cw;
+
+    INIT_OUTER_LOOP_4
+    intp is1 = steps[0], is2 = steps[1], is3 = steps[2];
+
+    fpu_fix_start(&old_cw);
+
+    BEGIN_OUTER_LOOP_4
+    char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *op = args[3];
+
+    load_point_qd(ip1, is1, A);
+    load_point_qd(ip2, is2, B);
+    load_point_qd(ip3, is3, C);
+
+    t_os_solid_angle_qd(A, B, C, &angle);
+
+    *(double *) op = angle.x[0];
+    END_OUTER_LOOP
+
+    fpu_fix_end(&old_cw);
+}
+
+static PyUFuncGenericFunction solid_angle_triangle_functions[] = {DOUBLE_solid_angle_triangle};
+static void *solid_angle_triangle_data[] = {(void *) NULL};
+static char solid_angle_triangle_signatures[] = {NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE};
 
 /*///////////////////////////////////////////////////////////////////////////
   intersection
@@ -729,13 +898,13 @@ DOUBLE_intersects_point(
     load_point_qd(ip2, is2, B);
     load_point_qd(ip3, is3, C);
 
-    if (normalize_qd(A, A)) {
+    if (normalize_qd(A, A, 0.0)) {
         return;
     }
-    if (normalize_qd(B, B)) {
+    if (normalize_qd(B, B, 0.0)) {
         return;
     }
-    if (normalize_qd(C, C)) {
+    if (normalize_qd(C, C, 0.0)) {
         return;
     }
 
@@ -812,6 +981,7 @@ DOUBLE_angle(char **args, const intp *dimensions, const intp *steps, void *NPY_U
     dot_qd(B, X, &diff);
     ret = normalized_dot_qd(ABX, BCX, &inner);
     if (ret == 1) {
+        PyErr_SetString(PyExc_ValueError, "Null vector.");
         return;
     } else if (ret == 2) {
         PyErr_Clear();
@@ -904,6 +1074,15 @@ addUfuncs(PyObject *dictionary)
     Py_DECREF(f);
 
     f = PyUFunc_FromFuncAndDataAndSignature(
+        solid_angle_triangle_functions, solid_angle_triangle_data, solid_angle_triangle_signatures,
+        1, 3, 1, PyUFunc_None, "solid_angle_triangle",
+        "Calculate the solid angle of a triangle.\n"
+        "     \"(i),(i),(i)->()\" \n",
+        0, solid_angle_triangle_signature);
+    PyDict_SetItemString(dictionary, "solid_angle_triangle", f);
+    Py_DECREF(f);
+
+    f = PyUFunc_FromFuncAndDataAndSignature(
         intersection_functions, intersection_data, intersection_signatures, 1, 4, 1, PyUFunc_None,
         "intersection",
         "intersection product of 3-vectors only \n"
@@ -947,8 +1126,150 @@ addUfuncs(PyObject *dictionary)
     Py_DECREF(f);
 }
 
+static PyObject *
+single_polygon_area(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    PyObject *inside_obj = NULL;
+    PyObject *points_obj = NULL;
+    PyArrayObject *points;
+    int has_inside = 0;
+    double area[4] = {0.0, 0.0, 0.0, 0.0};
+    double small_area = 0.0;
+    qd *a, *b, *c, *e, inside[3], centroid[3], angle;
+    qd *norm_points; // pointer to the normalized points
+    int i, j, n, closed = 0;
+
+    if (!PyArg_ParseTuple(args, "O|O", &points_obj, &inside_obj)) {
+        return NULL;
+    }
+
+    points = (PyArrayObject *) PyArray_FROM_OTF(points_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (points == NULL) {
+        PyErr_SetString(
+            PyExc_TypeError, "Failed to convert points to a NumPy array of type float64");
+        return NULL;
+    }
+
+    if (PyArray_NDIM(points) != 2 || PyArray_DIM(points, 1) != 3) {
+        PyErr_SetString(PyExc_ValueError, "Polygon vertices must be a 2D array of shape (N, 3)");
+        Py_DECREF(points);
+        return NULL;
+    }
+
+    if (inside_obj != NULL && inside_obj != Py_None) {
+        PyArrayObject *inside_arr =
+            (PyArrayObject *) PyArray_FROM_OTF(inside_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+
+        if (inside_arr == NULL || PyArray_NDIM(inside_arr) != 1 ||
+            PyArray_DIM(inside_arr, 0) != 3) {
+            PyErr_SetString(PyExc_ValueError, "Inside vector must be a length-3 array or None");
+            Py_XDECREF(inside_arr);
+            Py_DECREF(points);
+            return NULL;
+        }
+        load_np_vector_qd(inside_arr, inside);
+        normalize_qd(inside, inside, 0.0);
+        has_inside = 1;
+        Py_DECREF(inside_arr);
+    }
+    n = PyArray_DIM(points, 0);
+
+    // allocate memory for normalized points:
+    norm_points = (qd *) malloc(3 * n * sizeof(qd));
+    if (norm_points == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "Failed to allocate memory for normalized points");
+        Py_DECREF(points);
+        return NULL;
+    }
+
+    for (i = 0; i < n; ++i) {
+        load_np_vector_array_qd(points, i, norm_points + 3 * i);
+        normalize_qd(norm_points + 3 * i, norm_points + 3 * i, 0.0);
+    }
+    Py_DECREF(points);
+
+    a = norm_points;
+    b = norm_points + 3;
+    e = norm_points + 3 * (n - 1);
+
+    if (is_vertex_close((qd *) a, (qd *) e, 1e-14)) {
+        n -= 1;
+        closed = 1;
+    }
+
+    if (n < 3) {
+        free(norm_points);
+        PyErr_SetString(PyExc_ValueError, "Polygon must have at least 3 vertices");
+        return Py_BuildValue("d", 0.0);
+    }
+
+    for (i = 2; i < n; ++i) {
+        c = norm_points + 3 * i;
+        t_os_solid_angle_qd((qd *) a, (qd *) b, (qd *) c, &angle);
+        c_qd_add(area, angle.x, area);
+        b = c;
+        c += 3;
+    }
+
+    if (!closed) {
+        // last vertex already in e
+        t_os_solid_angle_qd(a, b, e, &angle);
+        c_qd_add(area, angle.x, area);
+    }
+
+    small_area = fabs(area[0]);
+
+    if (!has_inside) {
+        free(norm_points);
+        return Py_BuildValue("d", small_area);
+    }
+
+    // compute centroid of the polygon to determine if the inside vector
+    // is pointing inwards or outwards:
+    for (i = 0; i < 3; ++i) {
+        qd_set_zero(centroid + i);
+    }
+    for (i = 0; i < n; ++i) {
+        for (j = 0; j < 3; ++j) {
+            c_qd_add(centroid[j].x, (norm_points + 3 * i + j)->x, centroid[j].x);
+        }
+    }
+    free(norm_points);
+    normalize_qd(centroid, centroid, 1.0e-28);
+
+    if (QD_ISNAN(centroid)) {
+        return Py_BuildValue("d", small_area);
+    }
+
+    dot_qd((qd *) inside, (qd *) centroid, &angle);
+    if (angle.x[0] > 0.0) {
+        return Py_BuildValue("d", small_area);
+    } else {
+        return Py_BuildValue("d", 4.0 * M_PI - small_area);
+    }
+}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#endif
+
+static struct PyMethodDef math_util_methods[] = {
+    {"single_polygon_area", (PyCFunction) (void (*)(void)) single_polygon_area, METH_VARARGS,
+     "single_polygon_area(points, inside=None)\n"},
+    {NULL, NULL} /* sentinel */
+};
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT, "math_util", NULL, -1, NULL, NULL, NULL, NULL, NULL};
+    PyModuleDef_HEAD_INIT, "math_util", NULL, -1, math_util_methods, NULL, NULL, NULL, NULL};
 
 PyObject *
 PyInit_math_util(void)

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define _USE_MATH_DEFINES
 
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"


### PR DESCRIPTION
This PR makes a couple of improvements to a several algorithms that resulted in to unit tests previously marked with `xfail` to pass. Improvements are:

- Implemented a more robust polygon area computation using Oosterom-Strackee which replaces previous computation that used Girard's theorem.
- Implemented a more robust algorithm for detecting nearly identical polygons.
- Improved computation of arc-to-arc intersections in the ``great_circle_arc`` module. This fixed the two new added tests previously marked as `xfail`ing in #322.
- Added `eps` argument to `_cross_and_normalize` to guard against division by small numbers and made C code match Python code behavior.
- Improved graph tracing algorithm to decide which edge to pick at nodes with multiple edges. Previously the "middle" edge was picked up.

I left numerous questions that I had when I started looking at this code first time as comments. These could be removed after review or left in the code temporarily.

#### Regression tests:

- Roman: https://github.com/spacetelescope/RegressionTests/actions/runs/32446146327
- JWST: https://github.com/spacetelescope/RegressionTests/actions/runs/32446201664
