### PR TITLE
Improve intersects_point

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -323,10 +323,19 @@ class Graph:
         # one, otherwise the Edge will get hooked up to the nodes but
         # be orphaned.
         for edge in self._edges:
+            # Q: what happens when A and B are the same node?
+            # Should we allow self-pointing edges?
+            # if A is B and A.equals(B):
+            #     # TODO: clarify what to do with self-pointing edges.
+            #     # For now, don't add self-pointing edges.
+            #     return edge
             if ((A is edge._nodes[0] and
                  B is edge._nodes[1]) or
                 (A is edge._nodes[1] and
                  B is edge._nodes[0])):
+                # Q: is it possible for an edge to be between the same two
+                # nodes but not be the same edge?
+                #if source_polygons is not None:
                 edge._source_polygons.update(source_polygons)
                 return edge
 

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -280,16 +280,31 @@ def intersects_point(A, B, C):
     intersects : bool or array of bool
         If the point is on the line, returns `True`.
     """
-    if HAS_C_UFUNCS:
+    if not HAS_C_UFUNCS:
         return math_util.intersects_point(A, B, C)
 
-    total_length = length(A, B)
-    left_length = length(A, C)
-    right_length = length(C, B)
+    epsilon = 1e-12  # Tolerance for coplanarity and degenerate check
 
-    length_diff = np.abs((left_length + right_length) - total_length)
+    A = np.asanyarray(A) / np.linalg.norm(A, keepdims=True)
+    B = np.asanyarray(B) / np.linalg.norm(B, keepdims=True)
+    C = np.asanyarray(C) / np.linalg.norm(C, axis=-1, keepdims=True)
 
-    return length_diff < 3e-11
+    normal = np.cross(A, B)
+    norm = np.linalg.norm(normal)
+
+    # Antipodal or nearly parallel: no unique great circle
+    if norm < epsilon:
+        return np.zeros(C.shape[:-1], dtype=bool)
+
+    coplanar = (np.abs(C @ normal) / norm) < epsilon
+
+    ab = np.dot(A, B)
+    ac = np.dot(C, A)
+    bc = np.dot(C, B)
+
+    not_antipodal = ab > -1.0 + epsilon
+    interior_of_minor_arc = (ac >= ab) & (bc >= ab)
+    return coplanar & interior_of_minor_arc & not_antipodal
 
 
 def angle(A, B, C):

--- a/spherical_geometry/great_circle_arc.py
+++ b/spherical_geometry/great_circle_arc.py
@@ -280,7 +280,7 @@ def intersects_point(A, B, C):
     intersects : bool or array of bool
         If the point is on the line, returns `True`.
     """
-    if not HAS_C_UFUNCS:
+    if HAS_C_UFUNCS:
         return math_util.intersects_point(A, B, C)
 
     epsilon = 1e-12  # Tolerance for coplanarity and degenerate check

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -18,6 +18,12 @@ __all__ = ['SingleSphericalPolygon', 'SphericalPolygon',
            'MalformedPolygonError']
 
 
+if hasattr(np, 'float128'):
+    EXTENDED_FLT_TYPE = np.float128
+else:
+    EXTENDED_FLT_TYPE = np.longdouble
+
+
 class MalformedPolygonError(Exception):
     pass
 
@@ -717,7 +723,7 @@ class SingleSphericalPolygon(object):
         points = np.vstack((self._points, self._points[1]))
         angles = great_circle_arc.angle(points[:-2], points[1:-1], points[2:])
 
-        return np.sum(angles) - (len(angles) - 2) * np.pi
+        return float(np.sum(angles, dtype=EXTENDED_FLT_TYPE) - (len(angles) - 2) * np.pi)
 
     def union(self, other):
         """

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -628,7 +628,7 @@ def test_near_identical_polygons():
     # a slightly different polygon:
     for k in range(10):
         np.random.seed(k)
-        sigma = 1.0e-10 * k
+        sigma = 1.0e-10 * (k + 1)
 
         rng = np.random.default_rng(42)
         dxs = rng.normal(0.0, sigma, 4)

--- a/spherical_geometry/tests/test_union.py
+++ b/spherical_geometry/tests/test_union.py
@@ -358,11 +358,11 @@ def test_almost_identical_polygons_multi_union():
 
     # FIXME: https://github.com/spacetelescope/spherical_geometry/issues/244
     if sys.platform == "win32":
-        p_shapes = [(66, 3), (68, 3)]  # 32-bit Windows has different shape but not 64-bit Windows
+        p_shapes = [(45, 3)]  # 32-bit Windows has different shape but not 64-bit Windows
     else:
-        p_shapes = [(66, 3)]
+        p_shapes = [(45, 3)]
 
     p = polygon.SphericalPolygon.multi_union(polygons)
 
     assert np.shape(list(p.points)[0]) in p_shapes
-    assert abs(p.area() - 2.6672666e-8) < area_tol
+    assert abs(p.area() - 2.667312060112e-8) < area_tol

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -725,7 +725,7 @@ char *intersects_point_signature = "(i),(i),(i)->()";
  */
 static void
 DOUBLE_intersects_point(
-    char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func))
+    char **args, const intp *dimensions, const intp *steps, void *NPY_UNUSED(func))
 {
     qd A[3], B[3], C[3];
     qd normal[3];
@@ -738,7 +738,7 @@ DOUBLE_intersects_point(
     const double epsilon = 1e-16; // Tolerance for coplanarity and degenerate check
 
     INIT_OUTER_LOOP_4
-    npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2];
+    intp is1 = steps[0], is2 = steps[1], is3 = steps[2];
 
     fpu_fix_start(&old_cw);
 

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -76,6 +76,12 @@ typedef struct {
 double QD_ONE[4] = {1.0, 0.0, 0.0, 0.0};
 
 static NPY_INLINE void
+qd_set_zero(qd *v)
+{
+    v->x[0] = v->x[1] = v->x[2] = v->x[3] = 0.0;
+}
+
+static NPY_INLINE void
 load_point(const char *in, const intp s, double *out)
 {
     out[0] = (*(double *) in);
@@ -171,6 +177,22 @@ normalize_qd(const qd *A, qd *B)
 
     for (i = 0; i < 3; ++i) {
         c_qd_div(A[i].x, l, B[i].x);
+    }
+
+    return 0;
+}
+
+static NPY_INLINE int
+norm_qd(const qd *a, qd *l)
+{
+    size_t i;
+    double t[4];
+
+    qd_set_zero(l);
+
+    for (i = 0; i < 3; ++i) {
+        c_qd_sqr(a[i].x, t);
+        c_qd_add(l->x, t, l->x);
     }
 
     return 0;
@@ -703,58 +725,121 @@ char *intersects_point_signature = "(i),(i),(i)->()";
  */
 static void
 DOUBLE_intersects_point(
-    char **args, const intp *dimensions, const intp *steps, void *NPY_UNUSED(func))
+    char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func))
 {
-    qd A[3];
-    qd B[3];
-    qd C[3];
-
-    qd total;
-    qd left;
-    qd right;
-    double t1[4], t2[4];
-    int result;
-
+    qd A[3], B[3], C[3];
+    qd normal[3];
+    qd nrm;
+    qd dot_ab, dot_ac, dot_bc;
+    qd tmp;
+    int cmp;
     unsigned int old_cw;
 
+    const double epsilon = 1e-16; // Tolerance for coplanarity and degenerate check
+
     INIT_OUTER_LOOP_4
-    intp is1 = steps[0], is2 = steps[1], is3 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2];
 
     fpu_fix_start(&old_cw);
+
+    /* A and B are constant across the outer loop, i.e. s0 == 0 && s1 == 0.
+     * When that holds, do all A/B-only work once instead of once per point in C. */
+    int ab_invariant = (s0 == 0 && s1 == 0);
+    int degenerate = 0;
+
+    if (ab_invariant) {
+        // A and B are constant across the outer loop, load them once
+        char *ip1 = args[0], *ip2 = args[1];
+
+        load_point_qd(ip1, is1, A);
+        load_point_qd(ip2, is2, B);
+
+        if (normalize_qd(A, A) || normalize_qd(B, B)) {
+            BEGIN_OUTER_LOOP_4
+            *((npy_bool *) args[3]) = 0;
+            END_OUTER_LOOP
+            fpu_fix_end(&old_cw);
+            return;
+        }
+
+        cross_qd(A, B, normal);
+        norm_qd(normal, &nrm);
+
+        // degenerate check
+        c_qd_comp_qd_d(nrm.x, epsilon, &cmp);
+        degenerate = (cmp == -1);
+
+        if (!degenerate) {
+            dot_qd(A, B, &dot_ab);
+        }
+    }
 
     BEGIN_OUTER_LOOP_4
     char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *op = args[3];
 
-    load_point_qd(ip1, is1, A);
-    load_point_qd(ip2, is2, B);
+    if (!ab_invariant) {
+        /* General case: A/B may vary per point, redo everything. */
+        load_point_qd(ip1, is1, A);
+        load_point_qd(ip2, is2, B);
+
+        if (normalize_qd(A, A) || normalize_qd(B, B)) {
+            *((npy_bool *) op) = 0;
+            continue;
+        }
+
+        cross_qd(A, B, normal);
+        norm_qd(normal, &nrm);
+
+        // degenerate check for nearly parallel or antipodal A and B
+        c_qd_comp_qd_d(nrm.x, epsilon, &cmp);
+        if (cmp == -1) {
+            *((npy_bool *) op) = 0;
+            continue;
+        }
+
+        dot_qd(A, B, &dot_ab);
+    } else if (degenerate) {
+        *((npy_bool *) op) = 0;
+        continue;
+    }
+
     load_point_qd(ip3, is3, C);
-
-    if (normalize_qd(A, A)) {
-        return;
-    }
-    if (normalize_qd(B, B)) {
-        return;
-    }
     if (normalize_qd(C, C)) {
-        return;
+        *((npy_bool *) op) = 0;
+        continue;
     }
 
-    if (length_qd(A, B, &total)) {
-        return;
-    }
-    if (length_qd(A, C, &left)) {
-        return;
-    }
-    if (length_qd(C, B, &right)) {
-        return;
+    /* coplanar = |C·normal| / norm < epsilon */
+    dot_qd(C, normal, &tmp);
+    c_qd_abs(tmp.x, tmp.x);
+    c_qd_div(tmp.x, nrm.x, tmp.x);
+    c_qd_comp_qd_d(tmp.x, epsilon, &cmp);
+    if (cmp != -1) {
+        /* not coplanar -> can't be on the arc; skip the dot products below */
+        *((npy_bool *) op) = 0;
+        continue;
     }
 
-    c_qd_add(left.x, right.x, t1);
-    c_qd_sub(t1, total.x, t2);
-    c_qd_abs(t2, t1);
+    /* not untipodal: AB > -1 */
+    c_qd_comp_qd_d(dot_ab.x, -1.0 + epsilon, &cmp);
+    int not_antipodal = (cmp == 1);
 
-    c_qd_comp_qd_d(t1, 1e-10, &result);
-    *((npy_bool *) op) = (result == -1);
+    if (!not_antipodal) {
+        *((npy_bool *) op) = 0;
+        continue;
+    }
+
+    dot_qd(C, A, &dot_ac);
+    dot_qd(C, B, &dot_bc);
+
+    int ac_gt_ab, bc_gt_ab;
+    c_qd_comp(dot_ac.x, dot_ab.x, &ac_gt_ab);
+    c_qd_comp(dot_bc.x, dot_ab.x, &bc_gt_ab);
+
+    int interior_of_minor_arc = (ac_gt_ab >= 0) && (bc_gt_ab >= 0);
+
+    *((npy_bool *) op) = interior_of_minor_arc;
+
     END_OUTER_LOOP
 
     fpu_fix_end(&old_cw);


### PR DESCRIPTION
Improvements to the `intersects_point()` function. Instead of computing three arc length, the modified function uses cosines instead and an explicit test for coplanarity. This PR also adds a check for A and B being antipodal when arcs become undefined. This approach avoids loss of accuracy when one of the arcs (AC or BC) is small. Improvements to the C code (pulling normalizations of constant vectors out of the innermost loop) resulted in a 8x speed improvement of the total unit test runtime (locally, on my laptop). It is possible that intersections and unions will have even larger performance improvements.

Fixes https://github.com/spacetelescope/spherical_geometry/issues/168

#### Regression tests:

- Roman: https://github.com/spacetelescope/RegressionTests/actions/runs/32623141843
- JWST: https://github.com/spacetelescope/RegressionTests/actions/runs/32623199978

The single romancal test failure seems unrelated.