### PR TITLE
Fix undetermined results in vectorized math_utils functions in edge cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,13 @@ Release Notes
 
 - Added a check for degenerate polygons in the ``SingleSphericalPolygon``
   class. Orientation of a degenerate polygon is now reported as ``None``.
-  [#338]
+  [#340]
+
+- Fixed a couple of bugs in the quad-precision versions of ``length``,
+  ``angle``, ``cross_and_norm``, and ``normalize`` functions in the
+  ``math_util`` module due to which vectorized operations could stop at
+  the first error encountered leaving the rest of returned results
+  undetermined. [#339]
 
 
 1.4.0 (2026-03-11)

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -182,6 +182,15 @@ class SingleSphericalPolygon:
 
         self._points = points = np.asanyarray(points)
 
+        # Check that all vertices are not close to null vectors, which would
+        # cause problems with normalization and area calculations.
+        norms = np.linalg.norm(points, axis=1)
+
+        if np.any(norms < 1e-12):
+            self._degenerate = True
+            self._inside = None
+            return
+
         if len(points) < 4:
             self._inside = None
             raise ValueError("Polygon made of too few points")

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -182,15 +182,6 @@ class SingleSphericalPolygon:
 
         self._points = points = np.asanyarray(points)
 
-        # Check that all vertices are not close to null vectors, which would
-        # cause problems with normalization and area calculations.
-        norms = np.linalg.norm(points, axis=1)
-
-        if np.any(norms < 1e-12):
-            self._degenerate = True
-            self._inside = None
-            return
-
         if len(points) < 4:
             self._inside = None
             raise ValueError("Polygon made of too few points")

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -711,11 +711,13 @@ def test_math_util_length_domain():
     ]
 
     for b_i in b:
-        with pytest.raises(ValueError):
-            great_circle_arc.length(a, b_i)
+        with pytest.warns(RuntimeWarning):
+            c = great_circle_arc.length(a, b_i)
+        assert np.all(~np.isfinite(c))
 
-    with pytest.raises(ValueError):
-        great_circle_arc.length(a, b)
+    with pytest.warns(RuntimeWarning):
+        c = great_circle_arc.length(a, b)
+    assert np.all(~np.isfinite(c))
 
 
 def test_math_util_angle_nearly_coplanar_vec():

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -699,6 +699,7 @@ def test_math_util_length_domain():
         [0, 0, 0],
         [0, 0, np.nan],
         [0, 0, 0],
+        [1, 0, 0]
     ]
     b = [
         [0, 0, np.inf],
@@ -708,14 +709,19 @@ def test_math_util_length_domain():
         [0, 0, np.inf],
         [0, 0, 0],
         [0, 0, 0],
+        [0, 1, 0]
     ]
 
-    for b_i in b:
+    for b_i in b[:-1]:
         c = great_circle_arc.length(a, b_i)
-        assert np.all(~np.isfinite(c))
+        assert np.all(~np.isfinite(c[:-1]))
+
+    c = great_circle_arc.length(a, b[-1])
+    assert np.isfinite(c[-1])
 
     c = great_circle_arc.length(a, b)
-    assert np.all(~np.isfinite(c))
+    assert np.all(~np.isfinite(c[:-1]))
+    assert np.isclose(c[-1], np.pi / 2, rtol=0, atol=1e-15)
 
 
 def test_math_util_angle_nearly_coplanar_vec():

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -689,7 +689,7 @@ def test_math_util_angle_domain():
         great_circle_arc.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])[0]
     )
 
-
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_math_util_length_domain():
     a = [
         [np.nan, 0, 0],
@@ -711,12 +711,10 @@ def test_math_util_length_domain():
     ]
 
     for b_i in b:
-        with pytest.warns(RuntimeWarning):
-            c = great_circle_arc.length(a, b_i)
+        c = great_circle_arc.length(a, b_i)
         assert np.all(~np.isfinite(c))
 
-    with pytest.warns(RuntimeWarning):
-        c = great_circle_arc.length(a, b)
+    c = great_circle_arc.length(a, b)
     assert np.all(~np.isfinite(c))
 
 

--- a/spherical_geometry/tests/test_vector.py
+++ b/spherical_geometry/tests/test_vector.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from spherical_geometry.vector import normalize_vector
+
+
+def test_normalize_vector():
+    rng = np.random.default_rng(0)  # Ensure reproducibility for any random operations
+    nvec = 17  # >= 6
+    # Test normalization of a single vector of shape (3,)
+    single = rng.random(3)
+    single_normalized = normalize_vector(single)
+    assert np.allclose(np.linalg.norm(single_normalized), 1.0)
+
+    # Test normalization of a random vector of shape (N, 3)
+    random_2d = rng.random((nvec, 3))
+    random_normalized = normalize_vector(random_2d)
+    assert np.allclose(np.linalg.norm(random_normalized, axis=1), 1.0)
+
+    # Test normalization of a random vector of shape (N, 3) with a nan or zero
+    # vector in the middle of the array. assert vectors that follow are
+    # normalized correctly.
+    random_2d = rng.random((nvec, 3))
+    # null vector:
+    random_2d[nvec // 2 - 1] = 0.0
+    # nan vector:
+    #random_2d[nvec // 2 + 1, 0] = np.nan
+    random_2d[2] = np.nan
+    mask = np.ones(nvec, dtype=bool)
+    mask[nvec // 2 - 1] = False
+    #mask[nvec // 2 + 1] = False
+    mask[2] = False
+    random_normalized = normalize_vector(random_2d)
+
+    assert np.allclose(np.linalg.norm(random_normalized[mask], axis=1), 1.0, rtol=0, atol=1.0e-14)
+    # Ensure that the null and nan vectors remain unchanged
+    assert np.all(np.all(~np.isfinite(random_normalized[~mask]), axis=1))

--- a/spherical_geometry/tests/test_vector.py
+++ b/spherical_geometry/tests/test_vector.py
@@ -1,8 +1,10 @@
+import pytest
+
 import numpy as np
 
 from spherical_geometry.vector import normalize_vector
 
-
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_normalize_vector():
     rng = np.random.default_rng(0)  # Ensure reproducibility for any random operations
     nvec = 17  # >= 6

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -200,7 +200,6 @@ normalize_qd(const qd *A, qd *B, double eps)
         for (i = 0; i < 3; ++i) {
             c_qd_copy_d(NPY_NAN, B[i].x);
         }
-        PyErr_SetString(PyExc_ValueError, "Domain error in sqrt");
         return 2;
     }
     if (T[3][0] <= eps) {
@@ -519,10 +518,7 @@ DOUBLE_normalize(char **args, const intp *dimensions, const intp *steps, void *N
 
     load_point_qd(ip1, is1, IN);
 
-    if (normalize_qd(IN, OUT, 0.0)) {
-        *((double *) op) = NPY_NAN;
-        continue;
-    }
+    normalize_qd(IN, OUT, 0.0);
 
     save_point_qd(OUT, op, is2);
     END_OUTER_LOOP

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -520,7 +520,8 @@ DOUBLE_normalize(char **args, const intp *dimensions, const intp *steps, void *N
     load_point_qd(ip1, is1, IN);
 
     if (normalize_qd(IN, OUT, 0.0)) {
-        return;
+        *((double *) op) = NPY_NAN;
+        continue;
     }
 
     save_point_qd(OUT, op, is2);
@@ -601,9 +602,7 @@ DOUBLE_cross_and_norm(
     load_point_qd(ip2, is2, B);
 
     cross_qd(A, B, C);
-    if (normalize_qd(C, C, 1e-31)) { // return nan if norm < 1e-31
-        return;
-    }
+    normalize_qd(C, C, 1e-31); // if norm < 1e-31, C is NaN. set op to C
 
     save_point_qd(C, op, is3);
     END_OUTER_LOOP
@@ -803,7 +802,8 @@ DOUBLE_length(char **args, const intp *dimensions, const intp *steps, void *NPY_
     load_point_qd(ip2, is2, B);
 
     if (length_qd(A, B, &s)) {
-        return;
+        *((double *) op) = NPY_NAN;
+        continue;
     }
     *((double *) op) = s.x[0];
     END_OUTER_LOOP
@@ -906,14 +906,6 @@ DOUBLE_intersects_point(
 
     load_point_qd(ip3, is3, C);
 
-    if (normalize_qd(A, A, 0.0)) {
-        *((npy_bool *) op) = 0;
-        continue;
-    }
-    if (normalize_qd(B, B, 0.0)) {
-        *((npy_bool *) op) = 0;
-        continue;
-    }
     if (normalize_qd(C, C, 0.0)) {
         *((npy_bool *) op) = 0;
         continue;
@@ -1005,24 +997,17 @@ DOUBLE_angle(char **args, const intp *dimensions, const intp *steps, void *NPY_U
     cross_qd(C, B, BCX);
     cross_qd(ABX, BCX, X);
     dot_qd(B, X, &diff);
-    ret = normalized_dot_qd(ABX, BCX, &inner);
-    if (ret == 1) {
-        return;
-    } else if (ret == 2) {
+    if (normalized_dot_qd(ABX, BCX, &inner)) {
         PyErr_Clear();
-#if defined(NAN)
-        *((double *) op) = NAN;
-#else
-        *((double *) op) = strtod("NaN", NULL);
-#endif
+        *((double *) op) = NPY_NAN;
         continue;
     }
 
     c_qd_abs(inner.x, abs_inner);
     c_qd_comp(abs_inner, QD_ONE, &comp);
     if (inner.x[0] != inner.x[0] || comp == 1) {
-        PyErr_SetString(PyExc_ValueError, "Out of domain for acos");
-        return;
+        *((double *) op) = NPY_NAN;
+        continue;
     }
 
     c_qd_acos(inner.x, angle);

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -265,16 +265,6 @@ dot_qd(const qd *A, const qd *B, qd *C)
 
     c_qd_add(tmp[0], tmp[1], tmp[3]);
     c_qd_add(tmp[3], tmp[2], C->x);
-
-    // In Python 3.13 it seems that the code above sets a floating point error
-    // flag (when input vectors contain nan/inf values) and this raises a
-    // warning/error "RuntimeWarning: invalid value encountered in length"
-    // and which results in a SystemError once
-    // PyErr_SetString(PyExc_ValueError, "Out of domain for acos") is called
-    // in length_qd. This clears FP error flags before raising the above
-    // exception.
-    // Also See https://github.com/spacetelescope/spherical_geometry/pull/288
-    PyUFunc_clearfperr();
 }
 
 /*
@@ -296,17 +286,16 @@ normalized_dot_qd(const qd *A, const qd *B, qd *dot_val)
     c_qd_mul(aa.x, bb.x, aabb);
 
     if (aabb[0] < -0.0) {
-        PyErr_SetString(PyExc_ValueError, "Domain error in sqrt");
-        return 1;
+        c_qd_copy_d(NPY_NAN, dot_val->x);
+        return 2;
     }
 
     c_qd_sqrt(aabb, norm);
 
     if (norm[0] == 0.0) {
         /* return non-normalized value: */
-        PyErr_SetString(PyExc_ValueError, "Null vector.");
         c_qd_copy(ab.x, dot_val->x);
-        return 2;
+        return 1;
     } else {
         c_qd_div(ab.x, norm, dot_val->x);
     }
@@ -314,7 +303,6 @@ normalized_dot_qd(const qd *A, const qd *B, qd *dot_val)
     if ((*v0 == 1.0 && *v1 > 0.0 && *v1 < eps) || (*v0 == -1.0 && *v1 < 0.0 && *v1 > -eps)) {
         c_qd_copy_d(dot_val->x[0], dot_val->x);
     }
-
     return 0;
 }
 
@@ -398,7 +386,6 @@ length_qd(const qd *A, const qd *B, qd *l)
 
     if ((A[0].x[0] == 0.0 && A[1].x[0] == 0.0 && A[2].x[0] == 0.0) ||
         (B[0].x[0] == 0.0 && B[1].x[0] == 0.0 && B[2].x[0] == 0.0)) {
-        PyErr_SetString(PyExc_ValueError, "Null vector.");
         return 1;
     }
 
@@ -410,7 +397,6 @@ length_qd(const qd *A, const qd *B, qd *l)
 
     dot_qd(A, B, &s);
     if (ISNAN_QD(s)) {
-        PyErr_SetString(PyExc_ValueError, "Out of domain for atan2");
         return 1;
     }
     cross_qd(A, B, t);
@@ -801,6 +787,7 @@ DOUBLE_length(char **args, const intp *dimensions, const intp *steps, void *NPY_
         *((double *) op) = NPY_NAN;
         continue;
     }
+
     *((double *) op) = s.x[0];
     END_OUTER_LOOP
 
@@ -959,7 +946,7 @@ char *angle_signature = "(i),(i),(i)->()";
 static void
 DOUBLE_angle(char **args, const intp *dimensions, const intp *steps, void *NPY_UNUSED(func))
 {
-    int comp, ret;
+    int comp;
     qd A[3];
     qd B[3];
     qd C[3];
@@ -1214,9 +1201,7 @@ single_polygon_area(PyObject *NPY_UNUSED(self), PyObject *args)
     for (i = 0; i < n; ++i) {
         load_np_vector_array_qd(points, i, norm_points + 3 * i);
         if (normalize_qd(norm_points + 3 * i, norm_points + 3 * i, 0.0)) {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_ValueError, "Failed to normalize polygon vertex");
-            }
+            PyErr_SetString(PyExc_ValueError, "Failed to normalize polygon vertex");
             free(norm_points);
             Py_DECREF(points);
             return NULL;
@@ -1270,7 +1255,8 @@ single_polygon_area(PyObject *NPY_UNUSED(self), PyObject *args)
         }
     }
     free(norm_points);
-    if (normalize_qd(centroid, centroid, 1.0e-28) == 2) {
+    if (normalize_qd(centroid, centroid, 1.0e-28)) {
+        PyErr_SetString(PyExc_ValueError, "Failed to normalize centroid");
         return NULL;
     }
 


### PR DESCRIPTION
Fixed a couple of bugs in the quad-precision versions of ``length``, ``angle``, ``cross_and_norm``, and ``normalize`` functions in the ``math_util`` module due to which:
- vectorized operations could stop at the first error encountered leaving the rest of returned results undetermined.
- Added an extra check for degeneracy in the ``SingleSphericalPolygon`` initializer.
- removed unnecessary normalization of ``A``, and ``B`` in ``intersects_point``.
