### PR TITLE
Add degeneracy test. Fix orientation of degenerate polygons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Release Notes
 - Added tolerance parameter for normalizing vectors in the ``math_util``
   module. Fixed bugs related to vector normalization in edge cases. [#338]
 
+- Added a check for degenerate polygons in the ``SingleSphericalPolygon``
+  class. Orientation of a degenerate polygon is now reported as ``None``.
+  [#338]
+
 
 1.4.0 (2026-03-11)
 ==================

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -186,6 +186,15 @@ class SingleSphericalPolygon:
             self._inside = None
             raise ValueError("Polygon made of too few points")
 
+        # Check that all vertices are not close to null vectors, which would
+        # cause problems with normalization and area calculations.
+        norms = np.linalg.norm(points, axis=1)
+
+        if np.any(norms < 1e-12):
+            self._degenerate = True
+            self._inside = None
+            return
+
         orient, new_inside = self._get_orient(compute_inside=True)
         if orient is None:
             self._degenerate = True
@@ -280,7 +289,7 @@ class SingleSphericalPolygon:
 
     def _get_orient(self, compute_inside=False):
         npoints = len(self._points)
-        if npoints < 4:
+        if npoints < 4 or self._degenerate:
             return None, None
 
         points = np.vstack((self._points, self._points[1]))

--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -190,7 +190,7 @@ class SingleSphericalPolygon:
         # cause problems with normalization and area calculations.
         norms = np.linalg.norm(points, axis=1)
 
-        if np.any(norms < 1e-12):
+        if np.any(~np.isfinite(norms)) or np.any(norms < 2 ** -32):
             self._degenerate = True
             self._inside = None
             return

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -775,6 +775,31 @@ def test_degenerate_polygon():
     assert p._degenerate
     assert p.area() == 0.0
 
+    # Test that a polygon with a null vector is degenerate
+    # See test_concave_polygon_area() for details on the polygon points and
+    # their arrangement.
+    sqrt2 = 2.0 * math.sqrt(2)
+    sqrt3p1 = math.sqrt(3) + 1
+    sqrt3m1 = math.sqrt(3) - 1
+    sin25 = math.sin(math.radians(25))
+    cos25 = math.cos(math.radians(25))
+    p1 = np.array([1.0, 0.0, 0.0])
+    p2 = np.array([sqrt3p1 / sqrt2, sqrt3m1 / sqrt2, 0.0])
+    p3 = np.array([sqrt3m1 / sqrt2, sqrt3p1 / sqrt2, 0.0])
+    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2])
+    p5 = np.array([0.0, 0.0, 0.0])
+    p6 = np.array([(sqrt3p1 * cos25) / sqrt2, (sqrt3m1 * cos25) / sqrt2, sin25])
+    p7 = np.array([cos25, 0.0, sin25])
+    p8 = np.array([sqrt3p1 / sqrt2, 0, sqrt3m1 / sqrt2])
+
+    points = np.array([p1, p2, p3, p4, p5, p6, p7, p8])
+
+    p = polygon.SingleSphericalPolygon(points)
+    assert p.is_clockwise() is None
+    assert p.inside is None
+    assert p._degenerate
+    assert p.area() == 0.0
+
     # Test that a polygon on a great circle is degenerate:
     p = polygon.SphericalPolygon.from_lonlat(90 * np.arange(5), 5 * [0])
     assert p._degenerate

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -778,19 +778,19 @@ def test_degenerate_polygon():
     # Test that a polygon with a null vector is degenerate
     # See test_concave_polygon_area() for details on the polygon points and
     # their arrangement.
-    sqrt2 = 2.0 * math.sqrt(2)
+    sqrt2x2 = 2.0 * math.sqrt(2)
     sqrt3p1 = math.sqrt(3) + 1
     sqrt3m1 = math.sqrt(3) - 1
     sin25 = math.sin(math.radians(25))
     cos25 = math.cos(math.radians(25))
     p1 = np.array([1.0, 0.0, 0.0])
-    p2 = np.array([sqrt3p1 / sqrt2, sqrt3m1 / sqrt2, 0.0])
-    p3 = np.array([sqrt3m1 / sqrt2, sqrt3p1 / sqrt2, 0.0])
-    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2])
+    p2 = np.array([sqrt3p1 / sqrt2x2, sqrt3m1 / sqrt2x2, 0.0])
+    p3 = np.array([sqrt3m1 / sqrt2x2, sqrt3p1 / sqrt2x2, 0.0])
+    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2x2])
     p5 = np.array([0.0, 0.0, 0.0])
-    p6 = np.array([(sqrt3p1 * cos25) / sqrt2, (sqrt3m1 * cos25) / sqrt2, sin25])
+    p6 = np.array([(sqrt3p1 * cos25) / sqrt2x2, (sqrt3m1 * cos25) / sqrt2x2, sin25])
     p7 = np.array([cos25, 0.0, sin25])
-    p8 = np.array([sqrt3p1 / sqrt2, 0, sqrt3m1 / sqrt2])
+    p8 = np.array([sqrt3p1 / sqrt2x2, 0, sqrt3m1 / sqrt2x2])
 
     points = np.array([p1, p2, p3, p4, p5, p6, p7, p8])
 
@@ -847,7 +847,7 @@ def test_polygon_contains_inside_point():
 
 
 def test_concave_polygon_area():
-    sqrt2 = 2.0 * math.sqrt(2)
+    sqrt2x2 = 2.0 * math.sqrt(2)
     sqrt3p1 = math.sqrt(3) + 1
     sqrt3m1 = math.sqrt(3) - 1
     sin25 = math.sin(math.radians(25))
@@ -864,13 +864,13 @@ def test_concave_polygon_area():
     #       p1----p2------------p3
     #
     p1 = np.array([1.0, 0.0, 0.0])
-    p2 = np.array([sqrt3p1 / sqrt2, sqrt3m1 / sqrt2, 0.0])
-    p3 = np.array([sqrt3m1 / sqrt2, sqrt3p1 / sqrt2, 0.0])
-    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2])
-    p5 = np.array([(sqrt3p1**2) / 8.0, (sqrt3m1 * sqrt3p1) / 8.0, sqrt3m1 / sqrt2])
-    p6 = np.array([(sqrt3p1 * cos25) / sqrt2, (sqrt3m1 * cos25) / sqrt2, sin25])
+    p2 = np.array([sqrt3p1 / sqrt2x2, sqrt3m1 / sqrt2x2, 0.0])
+    p3 = np.array([sqrt3m1 / sqrt2x2, sqrt3p1 / sqrt2x2, 0.0])
+    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2x2])
+    p5 = np.array([(sqrt3p1**2) / 8.0, (sqrt3m1 * sqrt3p1) / 8.0, sqrt3m1 / sqrt2x2])
+    p6 = np.array([(sqrt3p1 * cos25) / sqrt2x2, (sqrt3m1 * cos25) / sqrt2x2, sin25])
     p7 = np.array([cos25, 0.0, sin25])
-    p8 = np.array([sqrt3p1 / sqrt2, 0, sqrt3m1 / sqrt2])
+    p8 = np.array([sqrt3p1 / sqrt2x2, 0, sqrt3m1 / sqrt2x2])
 
     area_t = polygon.SingleSphericalPolygon([p1, p2, p3, p4, p5, p6, p7, p8]).area()
 
@@ -911,7 +911,7 @@ def test_concave_polygon_area_with_multi_union():
     #
     # Once it passes, it can be merged with test_concave_polygon_area().
 
-    sqrt2 = 2.0 * math.sqrt(2)
+    sqrt2x2 = 2.0 * math.sqrt(2)
     sqrt3p1 = math.sqrt(3) + 1
     sqrt3m1 = math.sqrt(3) - 1
     sin25 = math.sin(math.radians(25))
@@ -928,13 +928,13 @@ def test_concave_polygon_area_with_multi_union():
     #       p1----p2------------p3
     #
     p1 = np.array([1.0, 0.0, 0.0])
-    p2 = np.array([sqrt3p1 / sqrt2, sqrt3m1 / sqrt2, 0.0])
-    p3 = np.array([sqrt3m1 / sqrt2, sqrt3p1 / sqrt2, 0.0])
-    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2])
-    p5 = np.array([(sqrt3p1**2) / 8.0, (sqrt3m1 * sqrt3p1) / 8.0, sqrt3m1 / sqrt2])
-    p6 = np.array([(sqrt3p1 * cos25) / sqrt2, (sqrt3m1 * cos25) / sqrt2, sin25])
+    p2 = np.array([sqrt3p1 / sqrt2x2, sqrt3m1 / sqrt2x2, 0.0])
+    p3 = np.array([sqrt3m1 / sqrt2x2, sqrt3p1 / sqrt2x2, 0.0])
+    p4 = np.array([sqrt3m1*sqrt3p1 / 8.0, sqrt3p1**2 / 8.0, sqrt3m1 / sqrt2x2])
+    p5 = np.array([(sqrt3p1**2) / 8.0, (sqrt3m1 * sqrt3p1) / 8.0, sqrt3m1 / sqrt2x2])
+    p6 = np.array([(sqrt3p1 * cos25) / sqrt2x2, (sqrt3m1 * cos25) / sqrt2x2, sin25])
     p7 = np.array([cos25, 0.0, sin25])
-    p8 = np.array([sqrt3p1 / sqrt2, 0, sqrt3m1 / sqrt2])
+    p8 = np.array([sqrt3p1 / sqrt2x2, 0, sqrt3m1 / sqrt2x2])
 
     area_t = polygon.SingleSphericalPolygon([p1, p2, p3, p4, p5, p6, p7, p8]).area()
 


### PR DESCRIPTION
- Added a check for degenerate polygons in the ``SingleSphericalPolygon`` class.
- Orientation of a degenerate polygon is now reported as ``None``.