### PR TITLE
add python 3.15 testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
           linux: py3-test-devdeps
           posargs: -v
 
-        - name: Python 3 with dev version of dependencies
+        - name: Python 3.15 with dev version of dependencies
           linux: py315-test-devdeps
           python-version: 3.15
           posargs: -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,3 +63,8 @@ jobs:
         - name: Python 3 with dev version of dependencies
           linux: py3-test-devdeps
           posargs: -v
+
+        - name: Python 3 with dev version of dependencies
+          linux: py315-test-devdeps
+          python-version: 3.15
+          posargs: -v

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ extras =
     test
 deps =
     devdeps: astropy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
     cov: pytest-cov
     numpy1x: numpy==1.*
     xdist: pytest-xdist


### PR DESCRIPTION
Add 3.15 testing to CI:
https://github.com/spacetelescope/spherical_geometry/actions/runs/33629839980/job/100246365093?pr=344

build failure looks unrelated.